### PR TITLE
Adds option parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,48 @@ title: Firebolt OpenRPC Tools
 # Firebolt OpenRPC Tools
 Tools to enable consistent Firebolt SDK generation.
 
-## Usage
-To install the package, run:
+## To Use
 
-```
-npm install @firebolt-js/openrpc
+  - First, `npm install`.
+  - Next, invoke the cli directly with `src/cli.js`. See below for arguments.
+
+## CLI Arguments
+
+`--task`: Tell the tool what you want it to do. `sdk|docs|openrpc|validate`. More on each below.
+
+`--source`: The relative or absolute path to the folder or file that the task will use.
+
+`--template`: The relative or absolute path to the folder or file containing template resources for the task.
+
+`--output`: The relative or absolute path to the folder or file that will hold the task's generated output.
+
+### SDK Generation
+
+Indicated by `--task sdk`. Generate the Firebolt JavaScript SDK from a json-rpc spec.
+
+### Document Generation
+
+Indicated by `--task docs`.
+
+### OpenRPC Generation
+
+Indicated by `--task openrpc`. Reads a spec for a json-rpc API and generates an openrpc document for it.
+
+### JSON-RPC Validation
+
+Indicated by `--task validate`. Reads a json-rpc spec and validates it.
+
+## CLI Shorthands
+
+Don't feel like typing? Use `-t` instead of `--task`. This object shows the mapping:
+
+```js
+const shortHands = {
+  't': '--task',
+  's': '--source',
+  'tm': '--template',
+  'o': '--output',
+  'ap': '--as-path',
+  'sm': '--static-modules'
+}
 ```

--- a/README.md
+++ b/README.md
@@ -2,16 +2,23 @@
 title: Firebolt OpenRPC Tools
 ---
 # Firebolt OpenRPC Tools
-Tools to enable consistent Firebolt SDK generation.
+Tools to enable consistent Firebolt SDK and document generation.
 
 ## To Use
 
   - First, `npm install`.
   - Next, invoke the cli directly with `src/cli.js`. See below for arguments.
 
+Alternatively, you may install globally using `npm install -g @firebolt-js/openrpc`, which will install the cli and add it to your $PATH so it may be invoked with the `firebolt-openrpc` command. However, trying this at the time of writing, it did not work.
+
 ## CLI Arguments
 
-`--task`: Tell the tool what you want it to do. `sdk|docs|openrpc|validate`. More on each below.
+`--task`: Tell the tool what you want it to do. Options are:
+
+  - `sdk`: Generate the SDK
+  - `docs`: Generate the docs
+  - `openrpc`: Generate the openrpc
+  - `validate` Validate the openrpc
 
 `--source`: The relative or absolute path to the folder or file that the task will use.
 
@@ -19,37 +26,35 @@ Tools to enable consistent Firebolt SDK generation.
 
 `--output`: The relative or absolute path to the folder or file that will hold the task's generated output.
 
-`--as-path`: I'm not sure what this does.
+`--as-path`: This has some effect on the document generation task. Not sure what.
 
-`--static-modules`: Makes sure that statically defined modules get exported. An example is `Platform`.
+`--static-modules`: Used by the SDK generator. Makes sure that statically defined modules get exported. An example is `Platform`.
 
 ### SDK Generation
 
-Indicated by `--task sdk`. Generate the Firebolt JavaScript SDK from a json-rpc spec.
+Indicated by `--task sdk`. Generate the Firebolt SDKs from an OpenRPC spec. Currently, only the JavaScript SDK is supported.
 
 ### Document Generation
 
-Indicated by `--task docs`.
+Indicated by `--task docs`. Generate markdown docs from the OpenRPC spec.
 
 ### OpenRPC Generation
 
-Indicated by `--task openrpc`. Reads a spec for a json-rpc API and generates an openrpc document for it.
+Indicated by `--task openrpc`. Assembles a corpus of individual OpenRPC documents into a single OpenRPC document.
 
-### JSON-RPC Validation
+### OpenRPC Validation
 
-Indicated by `--task validate`. Reads a json-rpc spec and validates it.
+Indicated by `--task validate`. Reads and validates a corpus of individual OpenRPC documents and validates the result of assembling them together into a single OpenRPC document.
 
 ## CLI Shorthands
 
-Don't feel like typing? Use `-t` instead of `--task`. This object shows the mapping:
+Don't feel like typing? Use `-t` instead of `--task`. This table shows the mapping:
 
-```js
-const shortHands = {
-  't': '--task',
-  's': '--source',
-  'tm': '--template',
-  'o': '--output',
-  'ap': '--as-path',
-  'sm': '--static-modules'
-}
-```
+| shorthand | command            |
+| --------- | ------------------ |
+| `-t`      | `--task`           |
+| `-s`      | `--source`         |
+| `-tm`     | `--template`       |
+| `-o`      | `--output`         |
+| `-ap`     | `--as-path`        |
+| `-sm`     | `--static-modules` |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Tools to enable consistent Firebolt SDK generation.
 
 `--output`: The relative or absolute path to the folder or file that will hold the task's generated output.
 
+`--as-path`: I'm not sure what this does.
+
+`--static-modules`: Makes sure that statically defined modules get exported. An example is `Platform`.
+
 ### SDK Generation
 
 Indicated by `--task sdk`. Generate the Firebolt JavaScript SDK from a json-rpc spec.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,23 @@ title: Firebolt OpenRPC Tools
 # Firebolt OpenRPC Tools
 Tools to enable consistent Firebolt SDK and document generation.
 
+- [Firebolt OpenRPC Tools](#firebolt-openrpc-tools)
+  - [To Use](#to-use)
+  - [CLI Arguments](#cli-arguments)
+    - [SDK Generation](#sdk-generation)
+      - [Note on --static-modules](#note-on---static-modules)
+    - [Document Generation](#document-generation)
+      - [Note on --as-path](#note-on---as-path)
+    - [OpenRPC Generation](#openrpc-generation)
+    - [OpenRPC Validation](#openrpc-validation)
+  - [CLI Shorthands](#cli-shorthands)
+
 ## To Use
 
   - First, `npm install`.
   - Next, invoke the cli directly with `src/cli.js`. See below for arguments.
 
-Alternatively, you may install globally using `npm install -g @firebolt-js/openrpc`, which will install the cli and add it to your $PATH so it may be invoked with the `firebolt-openrpc` command. However, trying this at the time of writing, it did not work.
+Alternatively, you may install globally using `npm install -g @firebolt-js/openrpc`, which will install the cli and add it to your $PATH so it may be invoked with the `firebolt-openrpc` command.
 
 ## CLI Arguments
 
@@ -26,17 +37,39 @@ Alternatively, you may install globally using `npm install -g @firebolt-js/openr
 
 `--output`: The relative or absolute path to the folder or file that will hold the task's generated output.
 
-`--as-path`: This has some effect on the document generation task. Not sure what.
+`--as-path`: Used by the document generator. This is a toggle for generating content as files vs folders. More info below in [Document Generation](/#document-generation).
 
-`--static-modules`: Used by the SDK generator. Makes sure that statically defined modules get exported. An example is `Platform`.
+`--static-modules`: String. Used by the SDK generator. "Static modules" are modules without an OpenRPC json document. More on this below.
 
 ### SDK Generation
 
 Indicated by `--task sdk`. Generate the Firebolt SDKs from an OpenRPC spec. Currently, only the JavaScript SDK is supported.
 
+#### Note on --static-modules
+
+Static modules are modules without a corresponding OpenRPC json document. It will be included statically from the location supplied by the `--template` option. Listing your module in the `--static-modules` property ensures that it is properly exported by the SDK and wires up mock responses as well.
+
 ### Document Generation
 
 Indicated by `--task docs`. Generate markdown docs from the OpenRPC spec.
+
+#### Note on --as-path
+
+When deploying docs to web servers, `--as-path` is generally used. For deploying to GitHub pages/wikis, do not use `--as-path`.
+
+This toggle will generate content as files vs folders. For exmaple, this:
+```
+/docs/Topic.md
+```
+vs
+```
+/docs/Topic/index.md
+```
+It affects the output of:
+
+  - file names
+  - relative links
+  - relative images
 
 ### OpenRPC Generation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "jest": "^27.3.1",
+        "nopt": "^5.0.0",
         "webpack-cli": "^4.8.0"
       }
     },
@@ -2634,6 +2635,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+      "dev": true
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -7798,6 +7805,21 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
       "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -12323,6 +12345,12 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
@@ -16380,6 +16408,15 @@
       "version": "1.1.75",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
       "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
+    },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "prepare:setup": "mkdir -p ./dist/docs ./build/docs/markdown ./build/sdk/javascript/src",
     "test": "jest --config=jest.config.js --detectOpenHandles",
     "build": "npm run validate && npm run build:docs && npm run build:sdk",
-    "validate": "npm run build:openrpc && node ./src/cli.mjs validate ./src",
-    "build:openrpc": "node ./src/cli.mjs openrpc ./src ./src/template/openrpc/template.json ./dist/sdk-open-rpc.json",
-    "build:sdk": "node ./src/cli.mjs sdk ./src/ ./src/template/js ./build/sdk/javascript/src",
-    "build:docs": "node ./src/cli.mjs docs ./src/ ./src/template/markdown ./build/docs/markdown asPath",
-    "build:wiki": "node ./src/cli.mjs docs ./src/ ./src/template/markdown ./build/docs/markdown",
+    "validate": "npm run build:openrpc && node ./src/cli.mjs --task validate --source ./src",
+    "build:openrpc": "node ./src/cli.mjs --task openrpc --source ./src --template ./src/template/openrpc/template.json --output ./dist/sdk-open-rpc.json",
+    "build:sdk": "node ./src/cli.mjs --task sdk --source ./src/ --template ./src/template/js --output ./build/sdk/javascript/src",
+    "build:docs": "node ./src/cli.mjs --task docs --source ./src/ --template ./src/template/markdown --output ./build/docs/markdown --as-path",
+    "build:wiki": "node ./src/cli.mjs --task docs --source ./src/ --template ./src/template/markdown --output ./build/docs/markdown",
     "dist": "npm run validate && npm run build:sdk && npm run build:docs && npm run pack && npm run test",
     "pack": "webpack --config webpack.config.js"
   },
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/rdkcentral/firebolt-core-sdk/blob/main/src/modules//ottx/firebolt-openrpc#readme",
   "devDependencies": {
     "jest": "^27.3.1",
+    "nopt": "^5.0.0",
     "webpack-cli": "^4.8.0"
   },
   "keywords": [

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -5,22 +5,43 @@ import docs from '../util/docs/index.mjs'
 import validate from '../util/validate/index.mjs'
 import openrpc from '../util/openrpc/index.mjs'
 import declarations from '../util/declarations/index.mjs'
+import nopt from 'nopt'
+import path from 'path'
 
-const args = process.argv.slice(2)
-const util = args.shift()
+const knownOpts = {
+  'task': [String, null],
+  'source': [path],
+  'template': [path],
+  'output': [path],
+  'as-path': Boolean,
+  'static-modules': String
+}
+const shortHands = {
+  't': '--task',
+  's': '--source',
+  'tm': '--template',
+  'o': '--output',
+  'ap': '--as-path',
+  'sm': '--static-modules'
+}
+// Last 2 arguments are the defaults.
+const parsedArgs = nopt(knownOpts, shortHands, process.argv, 2)
+const util = parsedArgs.task
 
 if (util === 'sdk') {
-    sdk(args)
+    sdk(parsedArgs)
 }
 else if (util === 'docs') {
-    docs(args)
+    docs(parsedArgs)
 }
 else if (util === 'validate') {
-    validate(args)
+    validate(parsedArgs)
 }
 else if (util === 'openrpc') {
-    openrpc(args)
+    openrpc(parsedArgs)
 }
 else if (util === 'declarations') {
-    declarations(args)
+    declarations(parsedArgs)
+} else {
+  console.log("Invalid build type")
 }

--- a/util/declarations/index.mjs
+++ b/util/declarations/index.mjs
@@ -36,11 +36,11 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
   // .tap(setVersion)
   // .tap(v => console.log(`\nVERSION ${v.major}.${v.minor}.${v.patch}`))
   // .collect()
-
-const run = args => {
-
-  const [srcFolderArg, outputFile] = args || process.argv.slice(3)
-
+// destructure well-known cli args and alias to variables expected by script
+const run = ({
+  source: srcFolderArg,
+  output: outputFile
+}) => {
   // Important file/directory locations
   const declarationsFile = path.join(outputFile)
   const schemasFolder = path.join(srcFolderArg, 'schemas')

--- a/util/docs/index.mjs
+++ b/util/docs/index.mjs
@@ -32,15 +32,18 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 /************************************************************************************************/
 /******************************************** MAIN **********************************************/
 /************************************************************************************************/
-
-const run = args => {
+// destructure well-known cli args and alias to variables expected by script
+const run = ({
+  source: srcFolderArg,
+  template: templateFolderArg,
+  output: outputFolderArg,
+  'as-path': asPath = false,
+}) => {
 
   setPathDelimiter('/template/markdown/')
   setSuffix('.md')
-  
-  const [srcFolderArg, templateFolderArg, outputFolderArg] = args
 
-  if (args.includes('asPath')) {
+  if (asPath) {
     setOptions({ asPath: true })
   }
 
@@ -59,7 +62,7 @@ const run = args => {
   const hasPublicMethods = json => json.methods && json.methods.filter(m => !m.tags || !m.tags.map(t=>t.name).includes('rpc-only')).length > 0
   const alphabeticalSorter = (a, b) => a.info.title > b.info.title ? 1 : b.info.title > a.info.title ? -1 : 0
   const fsCopyFile = h.wrapCallback(fs.copyFile)
-  const copyReadMe = _ => args.includes('asPath') ? fsCopyFile(apiIndex, path.join(outputFolder, 'index.md')) : fsCopyFile(readMe, path.join(outputFolder, 'index.md'))
+  const copyReadMe = _ => asPath ? fsCopyFile(apiIndex, path.join(outputFolder, 'index.md')) : fsCopyFile(readMe, path.join(outputFolder, 'index.md'))
   const createDocsDir = _ => h.wrapCallback(fs.mkdir)(path.join(outputFolder))
   const createSchemasDir = _ => h.wrapCallback(fs.mkdir)(path.join(outputFolder, 'schemas'))
   

--- a/util/openrpc/index.mjs
+++ b/util/openrpc/index.mjs
@@ -24,11 +24,12 @@ import { setTemplate, setVersion, mergeSchemas, mergeMethods, updateSchemaUris, 
 import path from 'path'
 import url from 'url'
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
-
-const run = args => {
-
-  const [srcFolderArg, templateArg, outputArg] = args
-
+// destructure well-known cli args and alias to variables expected by script
+const run = ({
+  source: srcFolderArg,
+  template: templateArg,
+  output: outputArg
+}) => {
   // Important file/directory locations
   const versionJson = path.join('package.json')
   const sharedSchemasFolder = path.join(__dirname, '..', '..', 'src', 'schemas')

--- a/util/sdk/index.mjs
+++ b/util/sdk/index.mjs
@@ -38,9 +38,13 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 /************************************************************************************************/
 /******************************************** MAIN **********************************************/
 /************************************************************************************************/
-const run = args => {
-  const [srcFolderArg, templateFolderArg, outputFolderArg, staticModules] = args || process.argv.slice(3)
-
+// destructure well-known cli args and alias to variables expected by script
+const run = ({
+  source: srcFolderArg,
+  template: templateFolderArg,
+  output: outputFolderArg,
+  'static-modules': staticModules = false
+}) => {
   // Important file/directory locations
   const versionJson = path.join('package.json')
   const modulesFolder = path.join(srcFolderArg, 'modules')

--- a/util/validate/index.mjs
+++ b/util/validate/index.mjs
@@ -34,12 +34,11 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 /************************************************************************************************/
 
 let errors = 0
-
-const run = args => {
-
+// destructure well-known cli args and alias to variables expected by script
+const run = ({
+  source: srcFolderArg
+}) => {
   logHeader(` VALIDATING... `)
-
-  const [srcFolderArg] = args || process.argv.slice(3)
 
   // Important file/directory locations
   const schemasFolder = path.join(srcFolderArg, 'schemas')


### PR DESCRIPTION
I hadn't looked at this in a while and it was pretty hard to tell how the cli was being used. There was a hack stuffed in to get a quick feature out of one of the util scripts that made it hard to understand how to use that feature (e.g. `asPath` and `staticModules`).

This makes all the script options explicit. I updated the README with the usage information.

I used the trusty [nopt](https://github.com/npm/nopt) package as the options parser.