### PR TITLE
Feature: Deprecated Methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firebolt-js/openrpc",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firebolt-js/openrpc",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/preset-env": "^7.15.0",

--- a/src/template/js/sdk/Transport/index.js
+++ b/src/template/js/sdk/Transport/index.js
@@ -36,11 +36,18 @@ export default class Transport {
     this._eventEmitters = []
     this._eventMap = {}
     this._queue = new Queue()
+    this._deprecated = {}
     this.isMock = false
   }
 
   static addEventEmitter (emitter) {
     Transport.get()._eventEmitters.push(emitter)
+  }
+
+  static registerDeprecatedMethod (module, method, alternative) {
+    Transport.get()._deprecated[module.toLowerCase() + '.' + method.toLowerCase()] = {
+      alternative: alternative || ''
+    }
   }
 
   _endpoint () {
@@ -96,6 +103,11 @@ export default class Transport {
       this._promises[this._id].promise = this
       this._promises[this._id].resolve = resolve
       this._promises[this._id].reject = reject
+
+      const deprecated = this._deprecated[module.toLowerCase() + '.' + method.toLowerCase()]
+      if (deprecated) {
+        console.warn(`WARNING: ${module}.${method}() is deprecated. ` + deprecated.alternative)
+      }
 
       // store the ID of the first listen for each event
       // TODO: what about wild cards?

--- a/util/declarations/generator/index.mjs
+++ b/util/declarations/generator/index.mjs
@@ -176,17 +176,26 @@ const generateMethods = json => compose(
     if (val.summary) {
       acc += `/**
  * ${val.summary}`
+    }
 
-      if (val.params && val.params.length) {
-        val.params.forEach(p => acc += `
+    const deprecated = val.tags && val.tags.find(t => t.name === 'deprecated')
+    
+    if (deprecated) {
+      acc += `
+ *
+ * @deprecated` + (deprecated['x-since'] ? ` since version ${deprecated['x-since']}` : '') + '.'
+    }
+
+    if (val.params && val.params.length) {
+      acc += `
+ *`
+      val.params.forEach(p => acc += `
  * @param {${getSchemaType(json, p.schema)}} ${p.name} ${p.summary}`)
-      }
+    }
 
       acc += `
  */
 `
-    }
-
     // if (!val.tags || !val.tags.find(t => t.name === 'synchronous')) {
     //   acc += getMethodSignature(json, val, { isInterface: false }).replace(/\)\:\s?(.*)/g, '): Promise<$1>') + '\n'
     // }

--- a/util/docs/macros/index.mjs
+++ b/util/docs/macros/index.mjs
@@ -214,6 +214,19 @@ function insertMethodMacros(data, method, module) {
 
     let method_data = data
 
+    const deprecated = method.tags && method.tags.find( t => t.name === 'deprecated')
+    if (deprecated ) {
+        let alternative = deprecated['x-alternative'] || ''
+        let since = deprecated['x-since'] || ''
+
+        if (alternative && alternative.indexOf(' ') === -1) {
+          alternative = `Use \`${alternative}\` instead.`
+        }
+    
+        method_data = method_data
+            .replace(/\$\{method.description\}/g, `This method is **deprecated**` + (since ? ` since version ${since}. ` : '. ') + `${alternative}\n\n\$\{method.description\}`)
+    }
+
     method_data = method_data
         .replace(/\$\{method.name\}/g, method.name)
         .replace(/\$\{event.name\}/g, method.name.length > 3 ? method.name[2].toLowerCase() + method.name.substr(3): method.name)


### PR DESCRIPTION
Add `deprecated` tag support for methods:

- does a `console.warn()` when calling a deprecated method
- Adds a note to the docs for each one
- Adds an annotation to the declarations file for each one
- Supports optional `x-alternative` attribute in openrpc to enhance the above three features
- Supports an optional `x-since` attribute in openrpc to enhance the above three features