### PR TITLE
fix(transport): Allow lazy loading of transport layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firebolt-js/openrpc",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firebolt-js/openrpc",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/preset-env": "^7.15.0",


### PR DESCRIPTION
This fix allows for a 500ms budget to lazy-load a transport layer, before the default mock is used.

Related to:
https://github.com/rdkcentral/firebolt-core-sdk/pull/10