### PR TITLE
fix(errors): Output pretty JSON parsing errors w/ filename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firebolt-js/openrpc",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firebolt-js/openrpc",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/preset-env": "^7.15.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare:setup": "mkdir -p ./dist/docs ./build/docs/markdown ./build/sdk/javascript/src",
     "test": "jest --config=jest.config.js --detectOpenHandles",
     "build": "npm run validate && npm run build:docs && npm run build:sdk",
-    "validate": "npm run build:openrpc && node ./src/cli.mjs --task validate --source ./src",
+    "validate": "node ./src/cli.mjs --task validate --source ./src && npm run build:openrpc && node ./src/cli.mjs --task validate --source ./dist",
     "build:openrpc": "node ./src/cli.mjs --task openrpc --source ./src --template ./src/template/openrpc/template.json --output ./dist/sdk-open-rpc.json",
     "build:sdk": "node ./src/cli.mjs --task sdk --source ./src/ --template ./src/template/js --output ./build/sdk/javascript/src",
     "build:docs": "node ./src/cli.mjs --task docs --source ./src/ --template ./src/template/markdown --output ./build/docs/markdown --as-path",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebolt-js/openrpc",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.3",
   "description": "The Firebolt SDK Code & Doc Generator",
   "bin": {
     "firebolt-openrpc": "./src/cli.mjs"

--- a/util/openrpc/index.mjs
+++ b/util/openrpc/index.mjs
@@ -96,7 +96,7 @@ const run = ({
     // Write it all to the output file
     .flatMap(writeOpenRPC)
     .done(() => {
-        logSuccess('Generated Firebolt OpenRPC document')
+        logSuccess('Generated Firebolt OpenRPC document\n')
     })
 }
 

--- a/util/shared/json-schema.mjs
+++ b/util/shared/json-schema.mjs
@@ -83,9 +83,9 @@ const loadAndParseSchema = filepath => h.of(filepath)
     .map(bufferToString)
     .map(JSON.parse)
     .errors( (err, push) => {
-      err.message = path.basename(filepath) + ": " + err.message
+      err.message = filepath + ": " + err.message
       console.error(`\n\x1b[41m ERROR:\x1b[0m ${err.message}\n`)
-      process.exit(1)
+      push(nil, err)
     })
     .map(addExternalMarkdown)
 

--- a/util/shared/json-schema.mjs
+++ b/util/shared/json-schema.mjs
@@ -76,9 +76,17 @@ const addExternalMarkdown = obj => {
 // DOES NOT DEAL WITH ERRORS
 const getSchemaContent = fileStream => fileStream
     .filter(filepath => path.extname(filepath) === '.json')
+    .flatMap(loadAndParseSchema)
+
+const loadAndParseSchema = filepath => h.of(filepath)
     .flatMap(fsReadFile)
     .map(bufferToString)
     .map(JSON.parse)
+    .errors( (err, push) => {
+      err.message = path.basename(filepath) + ": " + err.message
+      console.error(`\n\x1b[41m ERROR:\x1b[0m ${err.message}\n`)
+      process.exit(1)
+    })
     .map(addExternalMarkdown)
 
 const getRef = (ref, json) => {


### PR DESCRIPTION
We were getting ugly errors w/ no filename on JSON parse errors. Super unhelpful.

This feature adds:

- Code to track which file is being parsed
- Error catching that outputs a more readable error (w/ colors!) and a filename
- Moves individual module parsing _before_ merged OpenRPC parsing, to facilitate more useful debugging
- removes hard coded assumption that validate will always validate the merged file