### PR TITLE
fix(declarations): Create proper declarations for polymorphic pull & properties

### DIFF
--- a/util/shared/modules.mjs
+++ b/util/shared/modules.mjs
@@ -28,7 +28,7 @@ import logic from 'crocks/logic/index.js'
 const { and, not } = logic
 import isString from 'crocks/core/isString.js'
 import predicates from 'crocks/predicates/index.js'
-const { isObject, isArray, propEq, pathSatisfies } = predicates
+const { isObject, isArray, propEq, pathSatisfies, hasProp } = predicates
 import { fsReadFile, bufferToString } from './helpers.mjs'
 import { getSchemaContent } from './json-schema.mjs'
 
@@ -108,6 +108,13 @@ const isEventMethod = compose(
     option(false),
     map(_ => true),
     chain(find(propEq('name', 'event'))),
+    getPath(['tags'])
+)
+
+const isPolymorphicPullMethod = compose(
+    option(false),
+    map(_ => true),
+    chain(find(hasProp('x-pulls-for'))),
     getPath(['tags'])
 )
 
@@ -392,6 +399,7 @@ export {
     isEventMethod,
     isPublicEventMethod,
     isPolymorphicReducer,
+    isPolymorphicPullMethod,
     isExcludedMethod,
     isRPCOnlyMethod,
     hasExamples,


### PR DESCRIPTION
This fix does the following:

- Generates proper TS declarations for `property` & `property:readonly` subscribe APIs
- Generates proper TS declarations for `property` setter APIs
- Generates proper TS declarations for `polymorphic-pull` pull registration APIs
- Hides `roc-only` APIs from TS declarations