### PR TITLE
Fix Event API return types, support additionalProperties schemas

### DIFF
--- a/util/declarations/generator/index.mjs
+++ b/util/declarations/generator/index.mjs
@@ -116,13 +116,13 @@ const generateListeners = (json, schemas = {}) => compose(
   * Listen to all ${getModuleName(json)} events.
   * @param {Function} listener The listener function to handle the events.
   */
-  function listen(listener: (event: string, data: object) => {}): Promise<bigint>
+  function listen(listener: (event: string, data: object) => void): Promise<bigint>
 
   /**
   * Listen to one and only one instance of any ${getModuleName(json)} event (whichever is first).
   * @param {Function} listener The listener function to handle the events.
   */
-  function once(listener: (event: string, data: object) => {}): Promise<bigint>
+  function once(listener: (event: string, data: object) => void): Promise<bigint>
 `
   }
 
@@ -135,14 +135,14 @@ const generateListeners = (json, schemas = {}) => compose(
    * @param {Event} event The Event to listen to.
    * @param {Function} listener The listener function to handle the event.
    */
-  function listen(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => {}): Promise<bigint>
+  function listen(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => void): Promise<bigint>
 
   /**
    * Listen to one and only one instance of a specific ${getModuleName(json)} event.
    * @param {Event} event The Event to listen to.
    * @param {Function} listener The listener function to handle the event.
    */
-  function once(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => {}): Promise<bigint>
+  function once(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => void): Promise<bigint>
 
 `
   acc += `

--- a/util/declarations/generator/index.mjs
+++ b/util/declarations/generator/index.mjs
@@ -116,13 +116,13 @@ const generateListeners = (json, schemas = {}) => compose(
   * Listen to all ${getModuleName(json)} events.
   * @param {Function} listener The listener function to handle the events.
   */
-  function listen(listener: (event: string, data: object) => {})
+  function listen(listener: (event: string, data: object) => {}): Promise<bigint>
 
   /**
   * Listen to one and only one instance of any ${getModuleName(json)} event (whichever is first).
   * @param {Function} listener The listener function to handle the events.
   */
-  function once(listener: (event: string, data: object) => {})     
+  function once(listener: (event: string, data: object) => {}): Promise<bigint>
 `
   }
 
@@ -135,15 +135,22 @@ const generateListeners = (json, schemas = {}) => compose(
    * @param {Event} event The Event to listen to.
    * @param {Function} listener The listener function to handle the event.
    */
-  function listen(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => {})
+  function listen(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => {}): Promise<bigint>
 
   /**
    * Listen to one and only one instance of a specific ${getModuleName(json)} event.
    * @param {Event} event The Event to listen to.
    * @param {Function} listener The listener function to handle the event.
    */
-  function once(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => {})
+  function once(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => {}): Promise<bigint>
 
+`
+  acc += `
+  /**
+   * Clear all ${getModuleName(json)} listeners, or just the listener for a specific Id.
+   * @param {id} optional id of the listener to clear.
+   */
+  function clear(id?: bigint): boolean
 `
     return acc
   }, ''),
@@ -196,7 +203,7 @@ const subscriber = (json, val, schemas) => {
 `
   const type = val.name[0].toUpperCase() + val.name.substr(1)
 
-  acc += `function ${val.name}(subscriber: (${val.result.name}: ${getSchemaType(json, val.result.schema, schemas)}) => void): Promise<integer>\n`
+  acc += `function ${val.name}(subscriber: (${val.result.name}: ${getSchemaType(json, val.result.schema, schemas)}) => void): Promise<bigint>\n`
     
   return acc
 }

--- a/util/docs/macros/index.mjs
+++ b/util/docs/macros/index.mjs
@@ -79,9 +79,9 @@ export {
 function insertMacros(data = '', moduleJson = {}, templates = {}, schemas = {}, options = {}, version = {}) {
     let match, regex
     const methods = moduleJson.methods && moduleJson.methods.filter( method => !isEvent(method) && !isSetter(method) || (isEvent(method) && isFullyDocumentedEvent(method)) || isProviderMethod(method))
-    const additionalEvents = moduleJson.methods && moduleJson.methods.filter( method => isEvent(method) && !isFullyDocumentedEvent(method) && !isProviderMethod(m))
+    const additionalEvents = moduleJson.methods && moduleJson.methods.filter( method => isEvent(method) && !isFullyDocumentedEvent(method) && !isProviderMethod(method))
     
-    const hasEvents = (additionalEvents && additionalEvents.length > 0) || (methods && methods.find(m => isEvent(m) && !isProviderMethod(m)))
+    const hasEvents = (additionalEvents && additionalEvents.length > 0) || (methods && methods.find(method => isEvent(method) && !isProviderMethod(method)))
     const providerMethods = moduleJson.methods && moduleJson.methods.filter( method => isProviderMethod(method))
     const hasProviderMethods = (providerMethods && providerMethods.length > 0)
 

--- a/util/shared/typescript.mjs
+++ b/util/shared/typescript.mjs
@@ -101,11 +101,12 @@ function getSchemaShape(moduleJson = {}, json = {}, schemas = {}, name = '', opt
           structure.push(getSchemaShape(moduleJson, {type: type}, schemas, safeName(prop), {descriptions: descriptions, level: level+1}))
         })
       }
+      else if (json.additionalProperties && (typeof json.additionalProperties === 'object')) {
+        let type = getSchemaType(moduleJson, json.additionalProperties, schemas)
+        structure.push(getSchemaShape(moduleJson, {type: type}, schemas, '[property: string]', {descriptions: descriptions, level: level+1}))
+      }
       else if (json.patternProperties) {
-        Object.entries(json.patternProperties).forEach(([pattern, schema]) => {
-          let type = getSchemaType(moduleJson, schema, schemas)
-          structure.push(getSchemaShape(moduleJson, {type: type}, schemas, '\'/'+pattern+'/\'', {descriptions: descriptions, level: level+1}))
-        })        
+        throw "patternProperties are not supported by Firebolt"
       }
   
       structure.push('  '.repeat(level) + '}')


### PR DESCRIPTION
This PR fixes a few errors in our TypeScript Declarations:

- adds return types for the Event APIs in each module (listen, once, clear, subscribe)
- removes `patternProperties` from all OpenRPC schemas, as it does not translate to TypeScript
- uses `additionalProperties` as a schema instead (done for `BooleanMap` and `FlatMap`)
- changes event listener callbacks to return `void`, not `{}`

Related PR:
https://github.com/rdkcentral/firebolt-schemas/pull/6