### PR TITLE
Generate Beautiful Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firebolt-js/openrpc",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firebolt-js/openrpc",
-      "version": "1.3.0-alpha.1",
+      "version": "1.3.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/preset-env": "^7.15.0",

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -29,7 +29,7 @@ const shortHands = {
 }
 // Last 2 arguments are the defaults.
 const parsedArgs = nopt(knownOpts, shortHands, process.argv, 2)
-const signOff = () => console.log('This has been a presentation of Firebolt \u{1F525} \u{1F529}')
+const signOff = () => console.log('\nThis has been a presentation of \x1b[38;5;202mFirebolt\x1b[0m \u{1F525} \u{1F529}\n')
 
 const util = parsedArgs.task
 

--- a/util/declarations/generator/index.mjs
+++ b/util/declarations/generator/index.mjs
@@ -220,12 +220,12 @@ const setter = (json, val, schemas = {}) => {
 
   acc += `
  *
- * @param {${getSchemaType(val.result.schema)}} value The new ${val.name} value.
+ * @param {${getSchemaType(json, val.result.schema, schemas)}} value The new ${val.name} value.
  */
 `
   const type = val.name[0].toUpperCase() + val.name.substr(1)
 
-  acc += `function ${val.name}(value: ${getSchemaType(val.result.schema)}): Promise<void>\n`
+  acc += `function ${val.name}(value: ${getSchemaType(json, val.result.schema, schemas)}): Promise<void>\n`
     
   return acc
 }

--- a/util/declarations/index.mjs
+++ b/util/declarations/index.mjs
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fsWriteFile, logSuccess, fsMkDirP, logHeader, combineStreamObjects, schemaFetcher, localModules } from '../shared/helpers.mjs'
+import { fsWriteFile, logSuccess, fsMkDirP, logHeader, combineStreamObjects, schemaFetcher, localModules, trimPath } from '../shared/helpers.mjs'
 import { generateDeclarations } from './generator/index.mjs'
 import path from 'path'
 
@@ -55,7 +55,8 @@ const run = ({
       )
     )
     .tap(_ => {
-      logSuccess(`Wrote file: ${declarationsFile}`)
+      const filename = trimPath(declarationsFile)
+      logSuccess(`Wrote file: ${filename}`)
     })
 }
 

--- a/util/declarations/index.mjs
+++ b/util/declarations/index.mjs
@@ -35,7 +35,7 @@ const run = ({
   const sharedSchemasFolder = sharedSchemasFolderArg
   const modulesFolder = path.join(source, 'modules')
   const markdownFolder = path.join(source, 'declarations')
-  logHeader(`Generating typescript declarations file: ${declarationsFile}`)
+  logHeader(`Generating typescript declarations file: ${trimPath(declarationsFile)}`)
   const combinedSchemas = combineStreamObjects(schemaFetcher(sharedSchemasFolder), schemaFetcher(schemasFolder))
   const allModules = localModules(modulesFolder, markdownFolder) // Default behavior. Transforms and no private modules
   return fsMkDirP(declarationsDir)

--- a/util/docs/index.mjs
+++ b/util/docs/index.mjs
@@ -17,7 +17,7 @@
  */
 
 import h from 'highland'
-import { fsMkDirP, fsCopyFile, loadFilesIntoObject, combineStreamObjects, schemaFetcher, localModules, loadVersion } from '../shared/helpers.mjs'
+import { fsMkDirP, fsCopyFile, loadFilesIntoObject, combineStreamObjects, schemaFetcher, localModules, loadVersion, trimPath } from '../shared/helpers.mjs'
 import { clearDirectory, logSuccess, fsWriteFile } from '../shared/helpers.mjs'
 import { getDirectory, getFilename } from '../shared/helpers.mjs'
 import { insertMacros } from './macros/index.mjs'
@@ -83,10 +83,10 @@ const run = ({
     })
 
   return clearDirectory(outputFolder)
-    .tap(_ => logSuccess(`Removed ${outputFolder}`))
+    .tap(_ => logSuccess(`Removed ${trimPath(outputFolder)}`))
     .flatMap(fsMkDirP(path.join(outputFolder, 'schemas')))
     .flatMap(copyReadMe)
-    .tap(_ => logSuccess(`Created ${outputFolder}`))
+    .tap(_ => logSuccess(`Created ${trimPath(outputFolder)}`))
     .tap(_ => logSuccess(`Created index.md`))
     // This is basically a liftA4. This "lifts" a piece of synchronous data, the `insertMacros` function, indirectly through the `generateDocs` function,
     // into the context of 4 (A4 "arity 4") other pieces of asynchronous data: combinedTemplates, localModules, combinedSchemas, and loadVersion.
@@ -103,7 +103,10 @@ const run = ({
       console.log(err)
       push(null)
     })
-    .tap(file => logSuccess(`Created module doc: ${file}`))
+    .tap(file => {
+      const filename = trimPath(file, process.cwd())
+      logSuccess(`Created module doc: ${filename}`)
+    })
 }
 
 export default run

--- a/util/docs/macros/index.mjs
+++ b/util/docs/macros/index.mjs
@@ -418,6 +418,7 @@ function generatePropertySignatures (m) {
 function iterateSignatures(data, method, moduleJson = {}, schemas = {}, templates = {}, options = {}) {
     // we're hacking the schema here... make a copy!
     method = JSON.parse(JSON.stringify(method))
+    const module = moduleJson.info.title
     let signatures = [method]
     if (hasTag(method, 'property') || hasTag(method, 'property:readonly') || hasTag(method, 'property:immutable')) {
         signatures = generatePropertySignatures(method)
@@ -789,7 +790,7 @@ function generateRPCExample(example, m, moduleJson = {}) {
         return generatePropertyChangedRPCExample(example, m, moduleJson)
     }
     else if (m.tags && m.tags.filter(t => (t.name === 'property-set')).length) {
-        return generatePropertySetRPCExample(example, m, moduleJson)
+        return generatePropertySetRPCExample(example, m, moduleJson.info.title)
     }
     let request = {
         "jsonrpc": "2.0",

--- a/util/docs/macros/index.mjs
+++ b/util/docs/macros/index.mjs
@@ -418,7 +418,6 @@ function generatePropertySignatures (m) {
 function iterateSignatures(data, method, moduleJson = {}, schemas = {}, templates = {}, options = {}) {
     // we're hacking the schema here... make a copy!
     method = JSON.parse(JSON.stringify(method))
-    const module = moduleJson.info.title
     let signatures = [method]
     if (hasTag(method, 'property') || hasTag(method, 'property:readonly') || hasTag(method, 'property:immutable')) {
         signatures = generatePropertySignatures(method)
@@ -482,7 +481,7 @@ function iterateSignatures(data, method, moduleJson = {}, schemas = {}, template
             method.result.schema = possibleResults.find(s => s['$ref'] !== "https://meta.comcast.com/firebolt/types#/definitions/ListenResponse")
         }
         else {
-            console.log(`\nERROR: ${getTitle(module)}.${method.name} does not have two return types: both 'ListenResponse' and an event-specific payload\n`)
+            console.log(`\nERROR: ${getTitle(moduleJson.info.title)}.${method.name} does not have two return types: both 'ListenResponse' and an event-specific payload\n`)
             process.exit(1)
         }
     }

--- a/util/openrpc/index.mjs
+++ b/util/openrpc/index.mjs
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { loadVersion, logHeader, fsReadFile, combineStreamObjects, schemaFetcher, localModules, bufferToString, fsWriteFile, logSuccess, fsMkDirP } from '../shared/helpers.mjs'
+import { loadVersion, logHeader, fsReadFile, combineStreamObjects, schemaFetcher, localModules, bufferToString, fsWriteFile, logSuccess, fsMkDirP, trimPath } from '../shared/helpers.mjs'
 import path from 'path'
 import url from 'url'
 import { getMethods, getSchemas } from '../shared/modules.mjs'
@@ -35,7 +35,7 @@ const run = ({
   const modulesFolder = path.join(srcFolderArg, 'modules')
   const markdownFolder = path.join(srcFolderArg, 'descriptions')
 
-  logHeader(`MERGING into: ${outputArg}`)
+  logHeader(`MERGING into: ${trimPath(outputArg)}`)
 
   const templateFile = fsReadFile(templateArg).map(bufferToString).map(JSON.parse)
   const versionObj = loadVersion(path.join(srcFolderArg, '..', 'package.json'))

--- a/util/sdk/index.mjs
+++ b/util/sdk/index.mjs
@@ -19,7 +19,7 @@
  */
 
 import h from 'highland'
-import { fsWriteFile, localModules, combineStreamObjects, schemaFetcher, loadFilesIntoObject, clearDirectory, fsMkDirP, logSuccess, logHeader, loadVersion } from '../shared/helpers.mjs'
+import { fsWriteFile, localModules, combineStreamObjects, schemaFetcher, loadFilesIntoObject, clearDirectory, fsMkDirP, logSuccess, logHeader, loadVersion, trimPath } from '../shared/helpers.mjs'
 import { insertMacros, insertAggregateMacrosOnly, generateMacros, generateAggregateMacros } from './macros/index.mjs'
 import path from 'path'
 
@@ -124,7 +124,7 @@ const run = ({
       })
       .map(([k, v]) => [path.join(outputFolderArg, k), v]) // <-- concat output folder arg with template path
       .tap(([file, _]) => {
-        logSuccess(`Creating file: ${file}`)
+        logSuccess(`Creating file: ${trimPath(file)}`)
       })
       .flatMap(([file, contents]) => fsMkDirP(path.dirname(file))
         .flatMap(_ => fsWriteFile(file, contents)))
@@ -132,7 +132,7 @@ const run = ({
 
   logHeader(`Generating SDK into: ${outputFolderArg}`)
   return fsMkDirP(outputFolderArg)
-    .tap(_ => logSuccess(`Created folder: ${outputFolderArg}`))
+    .tap(_ => logSuccess(`Created folder: ${trimPath(outputFolderArg)}`))
     .flatMap(clearDirectory(outputFolderArg)
       .tap(_ => logSuccess("Cleared folder if it already existed."))
       .flatMap(_ => combinedSchemas

--- a/util/sdk/index.mjs
+++ b/util/sdk/index.mjs
@@ -130,7 +130,7 @@ const run = ({
         .flatMap(_ => fsWriteFile(file, contents)))
   }
 
-  logHeader(`Generating SDK into: ${outputFolderArg}`)
+  logHeader(`Generating SDK into: ${trimPath(outputFolderArg)}`)
   return fsMkDirP(outputFolderArg)
     .tap(_ => logSuccess(`Created folder: ${trimPath(outputFolderArg)}`))
     .flatMap(clearDirectory(outputFolderArg)

--- a/util/shared/helpers.mjs
+++ b/util/shared/helpers.mjs
@@ -223,7 +223,7 @@ const localModules = (modulesFolder = '', markdownFolder = '', disableTransforms
     .reduce({}, fileCollectionReducer('/modules/'))
   }
 
-  const trimPath = file => file.startsWith(process.cwd()) ? file.substr(process.cwd().length + 1) : file
+  const trimPath = file => path.relative(process.cwd(), file)
 
 export {
   loadFilesIntoObject,

--- a/util/shared/helpers.mjs
+++ b/util/shared/helpers.mjs
@@ -47,6 +47,7 @@ const clearDirectory = dir => fsRemoveDirectory(dir, {recursive: true})
 const isFile = dir => fsStat(dir).map(statObj => statObj.isFile())
 
 const logSuccess = message => console.log(`\x1b[32m ✓ \x1b[0m\x1b[2m ${message}\x1b[0m`)
+const logError = message => console.log(`\x1b[31m ✗ \x1b[0m\x1b[2m ${message}\x1b[0m`)
 const logHeader = message => console.log(`\x1b[0m\x1b[7m\x1b[32m${message}\x1b[0m\n`)
 
 // TODO: Convert to "stream" style fs functions
@@ -217,6 +218,8 @@ const localModules = (modulesFolder = '', markdownFolder = '', disableTransforms
     .reduce({}, fileCollectionReducer('/modules/'))
   }
 
+  const trimPath = file => file.startsWith(process.cwd()) ? file.substr(process.cwd().length + 1) : file
+
 export {
   loadFilesIntoObject,
   schemaFetcher,
@@ -231,8 +234,10 @@ export {
   fsWriteFile,
   fsReadFile,
   logSuccess,
+  logError,
   logHeader,
   getFilename,
   getDirectory,
-  getLinkFromRef
+  getLinkFromRef,
+  trimPath
 }

--- a/util/validate/index.mjs
+++ b/util/validate/index.mjs
@@ -91,10 +91,7 @@ const run = ({
     } else {
       filesWithErrorCount++
 
-      logError(`${moduleType}: ${result.title} failed validation with ${result.errors.length} errors:`)
-
-      // blank line for readablility
-      console.error()
+      logError(`${moduleType}: ${result.title} failed validation with ${result.errors.length} errors:\n`)
 
       result.errors.forEach( error => {
         displayError(error)

--- a/util/validate/index.mjs
+++ b/util/validate/index.mjs
@@ -17,8 +17,8 @@
  */
 
 import h from 'highland'
-import { logSuccess, logHeader, schemaFetcher, combineStreamObjects, localModules, bufferToString, fsReadFile, jsonErrorHandler } from '../shared/helpers.mjs'
-import { validate } from './validation/index.mjs'
+import { logSuccess, logHeader, schemaFetcher, combineStreamObjects, localModules, bufferToString, fsReadFile, jsonErrorHandler, logError } from '../shared/helpers.mjs'
+import { displayError, validate } from './validation/index.mjs'
 import path from 'path'
 import https from 'https'
 
@@ -56,7 +56,7 @@ const run = ({
   // Set up the ajv instance
   const ajv = new Ajv()
   addFormats(ajv)
-  let errorCounter = 0
+  let filesWithErrorCount = 0
 
   const combinedSchemas = combineStreamObjects(schemaFetcher(sharedSchemasFolder), schemaFetcher(schemasFolder), schemaFetcher(externalFolder))
   const allModules = localModules(modulesFolder, markdownFolder, disableTransforms, false) // Validate private modules
@@ -89,9 +89,16 @@ const run = ({
     if (result.valid) {
       logSuccess(`${moduleType}: ${result.title} is valid`)
     } else {
-      errorCounter++
-      console.error(result)
-      console.error(`\nERROR, ${moduleType}: ${result.title} failed validation. There are ${errorCounter} other errors`)
+      filesWithErrorCount++
+
+      logError(`${moduleType}: ${result.title} failed validation with ${result.errors.length} errors:`)
+
+      // blank line for readablility
+      console.error()
+
+      result.errors.forEach( error => {
+        displayError(error)
+      })
     }
   }
 
@@ -129,6 +136,14 @@ const run = ({
         .flatMap(schemas => fn(schemas) // Schema validation occurs here, then...
           .concat(openRpc(jsonSchemaSpec)
             .flatMap(orSpec => validateModules(ajvPackage(ajv, orSpec))(schemas)))))) // ...module validation
+            .collect()
+            .tap(_ => {
+              if (filesWithErrorCount > 0) {
+                // new line for easy-reading
+                console.log()
+                process.exit(-1)
+              }
+            })
 }
 
 export default run

--- a/util/validate/validation/index.mjs
+++ b/util/validate/validation/index.mjs
@@ -19,10 +19,85 @@ import { localizeDependencies } from '../../shared/json-schema.mjs'
 import crocks from 'crocks'
 const { getPathOr } = crocks
 
+const addPrettyPath = (error, json) => {
+  const path = []
+  const root = json.title || json.info.title
+
+  let pointer = json
+  error.instancePath.substr(1).split('/').forEach(x => {
+    if (x.match(/^[0-9]+$/)) {
+      path.push(pointer[parseInt(x)].name || pointer[parseInt(x)].title || x)
+      pointer = pointer[parseInt(x)]
+    }
+    else {
+      path.push(x)
+      pointer = pointer[x]
+    }
+  })
+  error.prettyPath = '/' + path.join('/')
+  error.document = root
+  return error
+}
+
+// this method keeps errors that are deeper in the JSON structure, and hides "parent" errors with an overlapping path
+export const pruneErrors = (errors = []) => {
+  const pruned = []
+  const paths = []
+
+  if (errors) {
+    return errors.filter((value, index, array) => {
+      if ((paths.length === 0) || (!paths.find(path => path.startsWith(value.instancePath)))) {
+        pruned.push(value)
+        paths.push(value.instancePath)
+        return true
+      }
+      return false
+    })
+  }
+  else return errors
+}
+
+// this method outputs a much more readable error than the raw JSON
+export const displayError = (error) => {
+  let errorLocation
+  let errorLocationType
+  let errorFileType
+
+  if (error.instancePath.startsWith('/components/schemas/')) {
+    errorLocation = error.instancePath.split('/').slice(3, 4).join('/')
+    errorLocationType = 'schema'
+    errorFileType = 'OpenRPC'
+  }
+  else if (error.instancePath.startsWith('/definitions/')) {
+    errorLocation = error.instancePath.split('/').slice(2, 3).join('/')
+    errorLocationType = 'schema'
+    errorFileType = 'JSON-Schema'
+  }
+  else if (error.instancePath.startsWith('/methods/')) {
+    errorLocation = error.prettyPath.split('/').slice(2, 3).join('/')
+    errorLocationType = 'method'
+    errorFileType = 'OpenRPC'
+  }
+
+  // hard to read this code, but these color escape codes make the errors glorious! :)
+  console.error(`Error in ${errorLocationType} '\x1b[32m${errorLocation}\x1b[0m'\n`)
+  console.error(`\t\x1b[2mpath:\x1b[0m     ${error.instancePath}`)
+  console.error(`\t\x1b[2mmessage:\x1b[0m  \x1b[38;5;2m${error.message}\x1b[0m`)
+  console.error(`\t\x1b[2mdocument:\x1b[0m \x1b[38;5;208m${error.document}\x1b[0m \x1b[2m(${errorFileType})\x1b[2m\x1b[0m`)
+
+  if (error.value) {
+    console.error(`\t\x1b[2mvalue:   \x1b[0m\n`)
+    console.dir(error.value, {depth: null, colors: true})// + JSON.stringify(example, null, '  ') + '\n')
+  }
+
+  console.error()
+}
+
 export const validate = (json = {}, schemas = {}, ajvPackage = []) => {
   const [validator, _] = ajvPackage
   let valid = validator(json)
   let root = json.title || json.info.title
+  const errors = []
 
   if (valid) {
     if (json.definitions) {
@@ -32,7 +107,11 @@ export const validate = (json = {}, schemas = {}, ajvPackage = []) => {
         const definition = JSON.parse(JSON.stringify(getPathOr({}, ['definitions', key], json)))
         if (Array.isArray(definition.examples)) {
           localizeDependencies(definition, json, schemas)
-          valid = valid && validateExamples(definition, root, ajvPackage)
+          const exampleResult = validateExamples(definition, root, ajvPackage, `/definitions/${key}`, ``, json)
+          valid = valid && exampleResult.valid
+          if (!exampleResult.valid) {
+            errors.push(...exampleResult.errors)
+          }
         }
       }
     }
@@ -52,7 +131,7 @@ export const validate = (json = {}, schemas = {}, ajvPackage = []) => {
                   localizeDependencies(param, json, schemas)
                   param.title = method.name + ' param \'' + p.name + '\''
                   param.examples = method.examples.map(ex => (ex.params.find(x => x.name === p.name) || { value: null }).value)
-                  valid = valid && validateExamples(param, root, ajvPackage)
+                  valid = valid && validateExamples(param, root, ajvPackage, `/methods/${i}/examples`, `/params/${j}`, json)
                 }
               }
 
@@ -60,42 +139,41 @@ export const validate = (json = {}, schemas = {}, ajvPackage = []) => {
               localizeDependencies(result, json, schemas)
               result.title = method.name + ' result'
               result.examples = examples
-              valid = valid && validateExamples(result, root, ajvPackage)
+              const exampleResult = validateExamples(result, root, ajvPackage, `/methods/${i}/examples`, `/result`, json)
+              valid = valid && exampleResult.valid
+              if (!exampleResult.valid) {
+                errors.push(...exampleResult.errors)
+              }
             }
+          }
+          else {
+            valid = false
+            errors.push({
+              instancePath: `/methods/${i}/examples`,
+              prettyPath: `/methods/${method.name}/examples`,
+              document: root,
+              message: 'must have at least one example'
+            })
           }
         }
         catch (e) {
           console.log('ERROR: ' + e)
-          console.dir(method.result.schema)
         }
       }
     }
   }
   else {
-    validator.errors.forEach(error => {
-      const path = []
-      let pointer = json
-      error.instancePath.substr(1).split('/').forEach(x => {
-        if (x.match(/^[0-9]+$/)) {
-          path.push(pointer[parseInt(x)].name || pointer[parseInt(x)].title || x)
-          pointer = pointer[parseInt(x)]
-        }
-        else {
-          path.push(x)
-          pointer = pointer[x]
-        }
-      })
-      error.prettyPath = '/' + path.join('/')
-    })
-    console.dir(validator.errors, {depth: null, colors: true})
+    validator.errors.forEach(error => addPrettyPath(error, json))
+    errors.push(...pruneErrors(validator.errors))
   } 
 
-  return { valid: valid, title: json.title || json.info.title }
+  return { valid: valid, title: json.title || json.info.title, errors: errors }
 }
 
-const validateExamples = (schema, root, ajvPackage = []) => {
+const validateExamples = (schema, root, ajvPackage = [], prefix = '', postfix = '', json) => {
   const [validator, ajv] = ajvPackage
   let valid = true
+  const errors = []
 
   try {
     const localValidator = ajv.compile(schema)
@@ -105,11 +183,14 @@ const validateExamples = (schema, root, ajvPackage = []) => {
       if (example && !localValidator(example)) {
         valid = false
         console.error(`${root} - ${schema.title} example ${index} failed!`)
-        console.log('\n')
-        console.dir(example, {depth: null, colors: true})// + JSON.stringify(example, null, '  ') + '\n')
-        console.log('\n')
-        console.dir(localValidator.errors, {depth: null, colors: true})
-        console.log('\n')
+
+        localValidator.errors.forEach(error => {
+          error.value = example
+          error.instancePath = prefix + `/${index}` + error.instancePath + postfix
+          error = addPrettyPath(error, json)
+        })
+
+        errors.push(...pruneErrors(localValidator.errors))
       }
       index++
     })
@@ -120,8 +201,18 @@ const validateExamples = (schema, root, ajvPackage = []) => {
   }
 
   if (schema.examples.length === 0) {
-    console.log(`\nWARNING: Schema ${schema.title} has no examples!\n`)
+    valid = false
+    errors.push({
+      instancePath: `${prefix}/examples`,
+      prettyPath: `${prefix}/examples`,
+      document: root,
+      message: 'must have at least one example'
+    })
   }
 
-  return valid
+  errors.forEach(error => {
+    displayError(error)
+  })
+
+  return { valid: valid, errors: errors }
 }


### PR DESCRIPTION
- Transform AJV errors into MUCH more human readable output
- Use color escape codes for error readability
- Add example errors to aggregate error list, and let calling method determine what to do (instead of logging an easy to ignore warning)
- call process.exit if there are any errors, but finish validating all files first (this prevents generating docs, sdk, etc., when there are errors)
- added explicit requirement for examples to exist