### PR TITLE
Generate docs/declarations for ProviderSession.focus()

### DIFF
--- a/src/template/markdown/index.md
+++ b/src/template/markdown/index.md
@@ -70,6 +70,18 @@ Providers are interfaces that your app can implement in order to provide certain
 
 To register a provider, use the [`provide()`](#provide) method.
 
+Every provider interface method has the following signature:
+
+```typescript
+(parameters: object | void, session: ProviderSession) => {}
+```
+
+`ProviderSession` has the following interface:
+
+```typescript
+${provider.session}
+```
+
 ${providers}
 
 ${end.if.providers}

--- a/src/template/markdown/provider-interface.md
+++ b/src/template/markdown/provider-interface.md
@@ -8,7 +8,7 @@ ${interface}
 Usage:
 
 ```typescript
-${info.title}.provide('${capability}', provider: ${provider} | Object)
+${info.title}.provide('${capability}', provider: ${provider} | object)
 ```
 
 ${provider.methods}

--- a/test/suite/provider.with-handshake.test.js
+++ b/test/suite/provider.with-handshake.test.js
@@ -97,8 +97,9 @@ test('Provide method called with two args (parameters, session)', () => {
     expect(numberOfArgs).toBe(2)
 })
 
-test('Provide method session arg DOES have focus', () => {
+test('Provide method session arg DOES have focus()', () => {
     expect(methodSession.hasOwnProperty('focus')).toBe(true)
+    expect(typeof methodSession.focus === 'function')
 })
 
 test('Provider response used correct correlationId', () => {

--- a/util/docs/macros/index.mjs
+++ b/util/docs/macros/index.mjs
@@ -20,7 +20,7 @@ import crocksHelpers from 'crocks/helpers/index.js'
 const { getPathOr, compose, tap } = crocksHelpers
 
 import { getLinkFromRef } from '../../shared/helpers.mjs'
-import { getMethodSignature, getMethodSignatureParams ,getSchemaType, getSchemaShape, getProviderInterface, getProviderName } from '../../shared/typescript.mjs'
+import { getMethodSignature, getMethodSignatureParams ,getSchemaType, getSchemaShape, getProviderInterface, getProviderName, getProviderSessionInterface } from '../../shared/typescript.mjs'
 import { getPath, getExternalPath, getExternalSchemaPaths, getSchemaConstraints, isDefinitionReferencedBySchema, localizeDependencies } from '../../shared/json-schema.mjs'
 import fs from 'fs'
 import pointfree from 'crocks/pointfree/index.js'
@@ -278,6 +278,8 @@ function insertMacros(data = '', moduleJson = {}, templates = {}, schemas = {}, 
             .replace(/\$\{toc.providers\}/g, capabilities.map(c => `    - [${getProviderName(c, moduleJson, schemas)}](#${getProviderName(c, moduleJson, schemas).toLowerCase})`).join('\n'))
     }
 
+    const providerSessionInterface = getProviderSessionInterface(moduleJson)
+
     data = data
         .replace(/\$\{module}/g, getTitle(moduleJson).toLowerCase() + '.json')
         .replace(/\$\{info.title}/g, getTitle(moduleJson))
@@ -286,6 +288,7 @@ function insertMacros(data = '', moduleJson = {}, templates = {}, schemas = {}, 
         .replace(/\$\{package.repository.name}/g, pkg.repository && pkg.repository.url && pkg.repository.url.split("/").slice(3,5).join("/") || '')
         .replace(/\$\{info.version}/g, version.readable)
         .replace(/\$\{info.description}/g, moduleJson.info && moduleJson.info.description || '')
+        .replace(/\$\{provider\.session}/g, providerSessionInterface)
 
     data = data.replace(/\$\{[a-zA-Z.]+\}\s*\n?/g, '') // remove left-over macros
 


### PR DESCRIPTION
Adds TypeScript declarations for session.focus():

- Generates `ProviderSession` interface w/ only correlationId()
- Generates `FocusableProviderSession` interface that extends and adds `focus()`
- adds these to docs and TS declarations.