### PR TITLE
fix: When setting boolean properties to false in mock transport, gett…

### DIFF
--- a/src/js/shared/Prop/MockProps.mjs
+++ b/src/js/shared/Prop/MockProps.mjs
@@ -6,7 +6,7 @@ function mock(module, method, args, def) {
   const fullMethod = `${module}.${method}`
   if ((args == null) || (args.length === 0)) {
     // get
-    const rv = mocks[fullMethod] && mocks[fullMethod].value ? mocks[fullMethod].value : def
+    const rv = mocks[fullMethod] && (mocks[fullMethod].value != null) ? mocks[fullMethod].value : def
     return rv
   } else {
     // set


### PR DESCRIPTION
…er is always returning default