### PR TITLE
Rename `global` to `globalObject`

### DIFF
--- a/src/js/shared/Transport/global.mjs
+++ b/src/js/shared/Transport/global.mjs
@@ -26,6 +26,6 @@ if (typeof self !== 'undefined') {
 	g = Function('return this')();
 } 
 
-const global = g
+const globalObject = g
 
-export default global
+export default globalObject


### PR DESCRIPTION
Jest 26 can't load modules with `global`:
https://github.com/facebook/jest/issues/10565

(yes, even if you don't export it... I was skeptical, too, but it's true)