### PR TITLE
Map integer type to Number instead of bigint

### DIFF
--- a/src/js/shared/Transport/index.mjs
+++ b/src/js/shared/Transport/index.mjs
@@ -27,6 +27,19 @@ const LEGACY_TRANSPORT_SERVICE_NAME = 'com.comcast.BridgeObject_1'
 let moduleInstance = null
 
 const isEventSuccess = x => x && (typeof x.event === 'string') && (typeof x.listening === 'boolean')
+const stringifyHelper = (key, value) => {
+  if (typeof value === 'bigint') {
+    if (value <= Number.MAX_SAFE_INTEGER) {
+      return Number(value)
+    }
+    else {
+      throw "bigint value is too large to serialize to JSON"
+    }
+  }
+  else {
+    return value
+  }
+}
 
 export default class Transport {
   constructor () {
@@ -103,7 +116,7 @@ export default class Transport {
     }
 
     const {promise, json, id } = this._processRequest(module, method, params)
-    const msg = JSON.stringify(json)
+    const msg = JSON.stringify(json, stringifyHelper)
     if (Settings.getLogLevel() === 'DEBUG') {
       console.debug('Sending message to transport: ' + msg)
     }
@@ -125,7 +138,7 @@ export default class Transport {
       json.push(result.json)
     })
 
-    const msg = JSON.stringify(json)
+    const msg = JSON.stringify(json, stringifyHelper)
     if (Settings.getLogLevel() === 'DEBUG') {
       console.debug('Sending message to transport: ' + msg)
     }

--- a/util/shared/typescript.mjs
+++ b/util/shared/typescript.mjs
@@ -427,7 +427,7 @@ function getSchemaShape(moduleJson = {}, json = {}, schemas = {}, name = '', opt
   
   function getTypeScriptType(jsonType) {
     if (jsonType === 'integer') {
-      return 'bigint'
+      return 'Number'
     }
     else {
       return jsonType

--- a/util/shared/typescript.mjs
+++ b/util/shared/typescript.mjs
@@ -185,7 +185,7 @@ function getSchemaShape(moduleJson = {}, json = {}, schemas = {}, name = '', opt
       }
     }
     else if (json.hasOwnProperty('const')) {
-      return '  '.repeat(level) + `${prefix}${title}${operator} ` + json.const
+      return '  '.repeat(level) + `${prefix}${title}${operator} ` + JSON.stringify(json.const)
     }
     else if (options.title && json.title) {
       let summary = ''
@@ -427,7 +427,7 @@ function getSchemaShape(moduleJson = {}, json = {}, schemas = {}, name = '', opt
   
   function getTypeScriptType(jsonType) {
     if (jsonType === 'integer') {
-      return 'Number'
+      return 'bigint'
     }
     else {
       return jsonType


### PR DESCRIPTION
bigint isn't valid JSON, so all of these schemas with bigint were actually impossible to use