### PR TITLE
Remove bigint

### DIFF
--- a/src/js/shared/Transport/index.mjs
+++ b/src/js/shared/Transport/index.mjs
@@ -27,19 +27,6 @@ const LEGACY_TRANSPORT_SERVICE_NAME = 'com.comcast.BridgeObject_1'
 let moduleInstance = null
 
 const isEventSuccess = x => x && (typeof x.event === 'string') && (typeof x.listening === 'boolean')
-const stringifyHelper = (key, value) => {
-  if (typeof value === 'bigint') {
-    if (value <= Number.MAX_SAFE_INTEGER) {
-      return Number(value)
-    }
-    else {
-      throw "bigint value is too large to serialize to JSON"
-    }
-  }
-  else {
-    return value
-  }
-}
 
 export default class Transport {
   constructor () {
@@ -116,7 +103,7 @@ export default class Transport {
     }
 
     const {promise, json, id } = this._processRequest(module, method, params)
-    const msg = JSON.stringify(json, stringifyHelper)
+    const msg = JSON.stringify(json)
     if (Settings.getLogLevel() === 'DEBUG') {
       console.debug('Sending message to transport: ' + msg)
     }
@@ -138,7 +125,7 @@ export default class Transport {
       json.push(result.json)
     })
 
-    const msg = JSON.stringify(json, stringifyHelper)
+    const msg = JSON.stringify(json)
     if (Settings.getLogLevel() === 'DEBUG') {
       console.debug('Sending message to transport: ' + msg)
     }

--- a/util/declarations/generator/index.mjs
+++ b/util/declarations/generator/index.mjs
@@ -122,13 +122,13 @@ const generateListeners = (json, schemas = {}) => compose(
   * Listen to all ${getModuleName(json)} events.
   * @param {Function} listener The listener function to handle the events.
   */
-  function listen(listener: (event: string, data: object) => void): Promise<bigint>
+  function listen(listener: (event: string, data: object) => void): Promise<number>
 
   /**
   * Listen to one and only one instance of any ${getModuleName(json)} event (whichever is first).
   * @param {Function} listener The listener function to handle the events.
   */
-  function once(listener: (event: string, data: object) => void): Promise<bigint>
+  function once(listener: (event: string, data: object) => void): Promise<number>
 `
   }
 
@@ -141,14 +141,14 @@ const generateListeners = (json, schemas = {}) => compose(
    * @param {Event} event The Event to listen to.
    * @param {Function} listener The listener function to handle the event.
    */
-  function listen(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => void): Promise<bigint>
+  function listen(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => void): Promise<number>
 
   /**
    * Listen to one and only one instance of a specific ${getModuleName(json)} event.
    * @param {Event} event The Event to listen to.
    * @param {Function} listener The listener function to handle the event.
    */
-  function once(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => void): Promise<bigint>
+  function once(event: '${val.name[2].toLowerCase() + val.name.substr(3)}', listener: (data: ${getSchemaType(json, result, schemas, {title: true})}) => void): Promise<number>
 
 `
   acc += `
@@ -156,7 +156,7 @@ const generateListeners = (json, schemas = {}) => compose(
    * Clear all ${getModuleName(json)} listeners, or just the listener for a specific Id.
    * @param {id} optional id of the listener to clear.
    */
-  function clear(id?: bigint): boolean
+  function clear(id?: number): boolean
 `
     return acc
   }, ''),
@@ -241,7 +241,7 @@ const subscriber = (json, val, schemas) => {
 `
   const type = val.name[0].toUpperCase() + val.name.substr(1)
 
-  acc += `function ${val.name}(subscriber: (${val.result.name}: ${getSchemaType(json, val.result.schema, schemas)}) => void): Promise<bigint>\n`
+  acc += `function ${val.name}(subscriber: (${val.result.name}: ${getSchemaType(json, val.result.schema, schemas)}) => void): Promise<number>\n`
     
   return acc
 }

--- a/util/docs/macros/index.mjs
+++ b/util/docs/macros/index.mjs
@@ -309,7 +309,7 @@ function insertMacros(data = '', moduleJson = {}, templates = {}, schemas = {}, 
         .replace(/\$\{package.name}/g, pkg.name)
         .replace(/\$\{package.repository}/g, pkg.repository && pkg.repository.url && pkg.repository.url.split("git+").pop().split("/blob").shift() || '')
         .replace(/\$\{package.repository.name}/g, pkg.repository && pkg.repository.url && pkg.repository.url.split("/").slice(3,5).join("/") || '')
-        .replace(/\$\{info.version}/g, version.readable)
+        .replace(/\$\{info.version}/g, version.original)
         .replace(/\$\{info.description}/g, moduleJson.info && moduleJson.info.description || '')
         .replace(/\$\{provider\.session}/g, providerSessionInterface)
 

--- a/util/shared/typescript.mjs
+++ b/util/shared/typescript.mjs
@@ -427,7 +427,7 @@ function getSchemaShape(moduleJson = {}, json = {}, schemas = {}, name = '', opt
   
   function getTypeScriptType(jsonType) {
     if (jsonType === 'integer') {
-      return 'bigint'
+      return 'number'
     }
     else {
       return jsonType


### PR DESCRIPTION
 Removed all bigint types from TypeScript declarations, in favor of number, since bigint is not widely supported across browsers.

Also fixed doc-generation version number.