### PR TITLE
Remove flattenSchemas hack, support true external references

### DIFF
--- a/util/shared/helpers.mjs
+++ b/util/shared/helpers.mjs
@@ -86,16 +86,6 @@ const recursiveFileDirectoryList = dirOrFile => {
   })
 }
 
-const urlList = url => 
-{
-  return h((push) => {
-    if (url) {
-      push(null, url)
-    }
-    push(null, h.nil)
-  })
-}
-
 // A through stream that expects a stream of filepaths, reads the contents
 // of any .suffix files found, and converts them to an array tuple that
 // has the filepath and the contents of the file.

--- a/util/shared/json-schema.mjs
+++ b/util/shared/json-schema.mjs
@@ -33,7 +33,7 @@ const getExternalMarkdownPaths = obj => {
 
 const refToPath = ref => {
   let path = ref.split('#').pop().substr(1).split('/')
-  return path.map(x => x.match(/[0-9]+/) ? parseInt(x) : x)
+  return path.map(x => x.match(/^[0-9]+$/) ? parseInt(x) : x)
 }
 
 const objectPaths = obj => {
@@ -63,7 +63,7 @@ const localRefPaths = obj => {
   return objectPaths(obj)
     .filter(x => /\/\$ref$/.test(x))
     .map(refToPath)
-    .filter(x => /^#/.test(getPathOr(null, x, obj)))
+    .filter(x => /^#.+/.test(getPathOr(null, x, obj)))
 }
 
 
@@ -171,9 +171,19 @@ const getPath = (uri = '', moduleJson = {}, schemas = {}) => {
 // grab a schema from another file in this project
 const getExternalPath = (uri = '', schemas = {}, localize = true, replace = true) => {
   const [mainPath, subPath] = uri.split('#')
-  const json = schemas[mainPath] || schemas[mainPath + '/']
+  const json = schemas[mainPath] || schemas[mainPath + '/'] 
+  
   // copy to avoid side effects
-  let result = JSON.parse(JSON.stringify(subPath ? getPathOr(null, subPath.slice(1).split('/'), json) : json))
+  let result
+
+  try {
+    result = JSON.parse(JSON.stringify(subPath ? getPathOr(null, subPath.slice(1).split('/'), json) : json))
+  }
+  catch (err) {
+    console.log(`Error loading ${uri}`)
+    console.log(err)
+    process.exit(100)
+  }
 
   if (localize) {
     result && (result = localizeDependencies(result, json, schemas))
@@ -267,23 +277,25 @@ const localizeDependencies = (def, schema, schemas = {}, options = defaultLocali
         let path = refs[i]      
         const ref = getPathOr(null, path, definition)
         path.pop() // drop ref
-        let resolvedSchema = JSON.parse(JSON.stringify(getPathOr(null, refToPath(ref), schema)))
+        if (refToPath(ref).length > 1) {
+          let resolvedSchema = JSON.parse(JSON.stringify(getPathOr(null, refToPath(ref), schema)))
         
-        if (!resolvedSchema) {
-          resolvedSchema = { "$REF": ref}
-          unresolvedRefs.push([...path])
-        }
-
-        if (path.length) {
-          // don't loose examples from original object w/ $ref
-          // todo: should we preserve other things, like title?
-          const examples = getPathOr(null, [...path, 'examples'], definition)
-          resolvedSchema.examples = examples || resolvedSchema.examples
-          definition = setPath(path, resolvedSchema, definition)
-        }
-        else {
-          delete definition['$ref']
-          Object.assign(definition, resolvedSchema)
+          if (!resolvedSchema) {
+            resolvedSchema = { "$REF": ref}
+            unresolvedRefs.push([...path])
+          }
+  
+          if (path.length) {
+            // don't loose examples from original object w/ $ref
+            // todo: should we preserve other things, like title?
+            const examples = getPathOr(null, [...path, 'examples'], definition)
+            resolvedSchema.examples = examples || resolvedSchema.examples
+            definition = setPath(path, resolvedSchema, definition)
+          }
+          else {
+            delete definition['$ref']
+            Object.assign(definition, resolvedSchema)
+          }  
         }
       }
       refs = localRefPaths(definition)
@@ -296,8 +308,14 @@ const localizeDependencies = (def, schema, schemas = {}, options = defaultLocali
       let path = refs[i]      
       const ref = getPathOr(null, path, definition)
       path.pop() // drop ref
-      let resolvedSchema = getExternalPath(ref, schemas, true)
+      let resolvedSchema
+
       
+      // only resolve our schemas for localization. TODO: make this a CLI param
+      if (ref.startsWith('https://meta.comcast.com/')) {
+        resolvedSchema = getExternalPath(ref, schemas, true)
+      }
+
       if (!resolvedSchema) {
         resolvedSchema = { "$REF": ref}
         unresolvedRefs.push([...path])
@@ -422,5 +440,6 @@ export {
   localizeDependencies,
   replaceUri,
   replaceRef,
-  flattenSchemas
+  flattenSchemas,
+  removeIgnoredAdditionalItems
 }

--- a/util/shared/json-schema.mjs
+++ b/util/shared/json-schema.mjs
@@ -108,23 +108,23 @@ const updateRefUris = (schema, uri) => {
 }
 
 const removeIgnoredAdditionalItems = schema => {
-  if (schema.hasOwnProperty('additionalItems')) {
+  if (schema && schema.hasOwnProperty && schema.hasOwnProperty('additionalItems')) {
     if (!schema.hasOwnProperty('items') || !Array.isArray(schema.items)) {
       delete schema.additionalItems
     }
   }
-  else if (typeof schema === 'object') {
+  else if (schema && (typeof schema === 'object')) {
     Object.keys(schema).forEach(key => removeIgnoredAdditionalItems(schema[key]))
   }
 }
 
 const replaceUri = (existing, replacement, schema) => {
-  if (schema.hasOwnProperty('$ref') && (typeof schema['$ref'] === 'string')) {
+  if (schema && schema.hasOwnProperty && schema.hasOwnProperty('$ref') && (typeof schema['$ref'] === 'string')) {
     if (schema['$ref'].indexOf(existing) === 0) {
       schema['$ref'] = schema['$ref'].split('#').map( x => x === existing ? replacement : x).join('#')
     }
   }
-  else if (typeof schema === 'object') {
+  else if (schema && (typeof schema === 'object')) {
     Object.keys(schema).forEach(key => {
       replaceUri(existing, replacement, schema[key])
     })

--- a/util/validate/index.mjs
+++ b/util/validate/index.mjs
@@ -77,9 +77,8 @@ const run = ({
     
   const jsonSchema = getJsonFromUrl('https://meta.json-schema.tools')
 
-  // flatten JSON-Schema into OpenRPC
   //  - OpenRPC uses `additionalItems` when `items` is not an array of schemas. This fails strict validate, so we remove it
-  //  - AJV can't seem to handle having a property's schema be the entire JSON-Schema spec, so we need to merge OpenRPC & JSON-Schema into one schema
+  //  - OpenRPC uses raw.githubusercontent.com URLs for the json-schema spec, we replace this with the up to date spec on meta.json-schema.tools
   const openRpc = jsSpec => getJsonFromUrl('https://meta.open-rpc.org')
     .map(orSpec => {
       removeIgnoredAdditionalItems(orSpec)

--- a/util/validate/validation/index.mjs
+++ b/util/validate/validation/index.mjs
@@ -122,6 +122,8 @@ export const displayError = (error) => {
     console.dir(error.value, {depth: null, colors: true})// + JSON.stringify(example, null, '  ') + '\n')
   }
 
+  console.dir(error, {depth: 1000})
+
   console.error()
 }
 
@@ -159,7 +161,7 @@ export const validate = (json = {}, schemas = {}, ajvPackage = [], additionalPac
       })
 
       for (let i=0; i<json.methods.length; i++) {
-        let method = localizeDependencies(json.methods[i], json)
+        let method = localizeDependencies(json.methods[i], json, schemas)
         try {
           if (method.examples) {
             const result = localizeDependencies(method.result.schema, json, schemas)


### PR DESCRIPTION
This PR removes the hacky logic to flatten the JSON-Schema schemas into the OpenRPC schema so that any `rpc.discover` examples provide by SDKs will actually validate.