### PR TITLE
Add support for copying external schemas to components.schemas

### DIFF
--- a/util/sdk/index.mjs
+++ b/util/sdk/index.mjs
@@ -92,7 +92,7 @@ const run = ({
 
     const macrofiedModules = h(Object.values(modules)
       .concat(Object.values(staticModules))) // <-- Static modules also get the macrofication spa treatment
-      .map(module => localizeDependencies(module, module, schemas, true))
+      .map(module => localizeDependencies(module, module, schemas, { externalOnly: true, keepRefsAndLocalizeAsComponent: true }))
       .flatMap(module => {
         const macros = macrosAlmost(module) // <-- call generateMacros with final async context
 


### PR DESCRIPTION
This fix adds an option to `localizeDependencies` that copies external schemas into `this.components.schemas` and updates all of the `$ref`s to be local paths.

The feature is then enabled when calling `localizeDependencies` on each module in the SDK task, which enables code generation of shared enums.