### PR TITLE
Add provider errors

### DIFF
--- a/test/suite/provider-errors.test.js
+++ b/test/suite/provider-errors.test.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Provider } from '../../build/sdk/javascript/src/sdk.mjs'
+import Setup from '../Setup.js'
+import { transport } from '../TransportHarness.js'
+
+let providerMethodNotificationRegistered = false
+let providerMethodRequestDispatched = false
+let providerMethodErrorSent = false
+let methodSession
+let value
+let responseCorrelationId
+
+
+beforeAll( () => {
+
+    class SimpleProvider {
+        simpleMethod(...args) {
+            methodSession = args[1]
+
+            throw {
+                message: 'An error occured!',
+                code: 50,
+                data: {
+                    info: 'the_info'
+                }
+            }
+        }
+    }
+    
+    transport.onSend(json => {
+        if (json.method === 'provider.onRequestSimpleMethod') {
+            providerMethodNotificationRegistered = true
+
+            // Confirm the listener is on
+            transport.response(json.id, {
+                listening: true,
+                event: json.method
+            })
+
+            // send out a request event
+            setTimeout( _ => {
+                providerMethodRequestDispatched = true
+                transport.response(json.id, {
+                    correlationId: 123
+                })
+            })
+        }
+        else if (json.method === 'provider.simpleMethodError') {
+            providerMethodErrorSent = true
+            value = json.params.error
+            responseCorrelationId = json.params.correlationId
+        }
+    })
+
+    Provider.provide('xrn:firebolt:capability:test:simple', new SimpleProvider())    
+
+    return new Promise( (resolve, reject) => {
+        setTimeout(resolve, 100)
+    })
+})
+
+test('Provider as Class registered', () => {
+    // this one is good as long as there's no errors yet
+    expect(1).toBe(1)
+});
+
+test('Provider method notification turned on', () => {
+    expect(providerMethodNotificationRegistered).toBe(true)
+})
+
+test('Provider method request dispatched', () => {
+    expect(providerMethodRequestDispatched).toBe(true)
+})
+
+test('Provide method session arg has correlationId', () => {
+    expect(methodSession.correlationId()).toBe(123)
+})
+
+test('Provide method session arg DOES NOT have focus', () => {
+    expect(methodSession.hasOwnProperty('focus')).toBe(false)
+})
+
+test('Provider response used correct correlationId', () => {
+    expect(responseCorrelationId).toBe(123)
+})
+
+test('Provider method error is correct', () => {
+    expect(value.code).toBe(50)
+    expect(value.data.info).toBe('the_info')
+})

--- a/util/shared/modules.mjs
+++ b/util/shared/modules.mjs
@@ -509,39 +509,40 @@ const createFocusFromProvider = provider => {
     return ready
 }
 
-const createResponseFromProvider = (provider, json) => {
+// type = Response | Error
+const createResponseFromProvider = (provider, type, json) => {
 
     if (!provider.name.startsWith('onRequest')) {
         throw "Methods with the `x-provider` tag extension MUST start with 'onRequest'."
     }
 
     const response = JSON.parse(JSON.stringify(provider))
-    response.name = response.name.charAt(9).toLowerCase() + response.name.substr(10) + 'Response'
-    response.summary = `Internal API for ${provider.name.substr(9)} Provider to send back a response.`
+    response.name = response.name.charAt(9).toLowerCase() + response.name.substr(10) + type
+    response.summary = `Internal API for ${provider.name.substr(9)} Provider to send back ${type.toLowerCase()}.`
     const old_tags = response.tags
     response.tags = [
         {
-            'name': 'rpc-only',
-            'x-response-for': provider.name
+            'name': 'rpc-only'
         }
     ]
+    response.tags[`x-${type.toLowerCase()}-for`] = provider.name
 
     const paramExamples = []
 
-    if (provider.tags.find(t => t['x-response'])) {
+    if (provider.tags.find(t => t[`x-${type.toLowerCase()}`])) {
         response.params = [
             {
-                name: 'response',
+                name: type.toLowerCase(),
                 required: true,
                 schema: {
                     allOf: [
                         {
-                            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/ProviderResponse"
+                            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/ProviderResponse" // use this schema for both Errors and Results
                         },
                         {
                             "type": "object",
                             "properties": {
-                                "result": provider.tags.find(t => t['x-response'])['x-response']
+                                "result": provider.tags.find(t => t[`x-${type.toLowerCase()}`])[`x-${type.toLowerCase()}`]
                             }
                         }
                     ]
@@ -549,7 +550,36 @@ const createResponseFromProvider = (provider, json) => {
             }
         ]
 
-        const schema = localizeDependencies(provider.tags.find(t => t['x-response'])['x-response'], json)
+        if (!provider.tags.find(t => t['x-error'])) {
+            provider.tags.find(t => t.name === 'event')['x-error'] = {
+                //"$ref": "https://meta.open-rpc.org/#definitions/errorObject"
+                // TODO: replace this with ref above (requires merge of `fix/rpc.discover`)
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "properties": {
+                  "code": {
+                    "title": "errorObjectCode",
+                    "description": "A Number that indicates the error type that occurred. This MUST be an integer. The error codes from and including -32768 to -32000 are reserved for pre-defined errors. These pre-defined errors SHOULD be assumed to be returned from any JSON-RPC api.",
+                    "type": "integer"
+                  },
+                  "message": {
+                    "title": "errorObjectMessage",
+                    "description": "A String providing a short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                  },
+                  "data": {
+                    "title": "errorObjectData",
+                    "description": "A Primitive or Structured value that contains additional information about the error. This may be omitted. The value of this member is defined by the Server (e.g. detailed error information, nested errors etc.)."
+                  }
+                }
+            }
+        }
+
+        const schema = localizeDependencies(provider.tags.find(t => t[`x-${type.toLowerCase()}`])[`x-${type.toLowerCase()}`], json)
 
         let n = 1
         if (schema.examples && schema.examples.length) {
@@ -557,7 +587,7 @@ const createResponseFromProvider = (provider, json) => {
                 name: schema.examples.length === 1 ? "Example" : `Example #${n++}`,
                 params: [
                     {
-                        name: 'response',
+                        name: `${type.toLowerCase()}`,
                         value: {
                             correlationId: "123",
                             result: param
@@ -576,7 +606,7 @@ const createResponseFromProvider = (provider, json) => {
                 name: 'Generated Example',
                 params: [
                     {
-                        name: 'response',
+                        name: `${type.toLowerCase()}`,
                         value: {
                             correlationId: "123",
                             result: {
@@ -592,12 +622,21 @@ const createResponseFromProvider = (provider, json) => {
             })
         }
     }
-    else {
-        response.params = []
+    
+    if (paramExamples.length === 0) {
+        const value = type === 'Error' ? { code: 1, message: 'Error' } : {}
         paramExamples.push(
             {
                 name: 'Example 1',
-                params: [],
+                params: [
+                    {
+                        name: `${type.toLowerCase()}`,
+                        value: {
+                            correlationId: "123",
+                            result: value
+                        }                        
+                    }
+                ],
                 result: {
                     name: 'result',
                     value: null
@@ -670,7 +709,8 @@ const generateProviderMethods = json => {
     })
 
     providers.forEach(provider => {
-        json.methods.push(createResponseFromProvider(provider, json))
+        json.methods.push(createResponseFromProvider(provider, 'Response', json))
+        json.methods.push(createResponseFromProvider(provider, 'Error', json))
     })
 
     return json


### PR DESCRIPTION
Adds a system for providers to send RPC error responses.

- Auto-generates `Provider.<method>Error` RPC methods for all Providers
- Automatically creates a basic error example, so that not all `x-error` schemas need one
- Inserts a temporary schema for the error (should be replaced w/ a link to official OpenRPC schema, but that depends on `fix/rpc.discover` so we'll do it after that is merged
- catches any errors when calling provider's in JS  SDK
- calls the RPC handler for errors when one is caught