### PR TITLE
Support enums with xrn values

### DIFF
--- a/util/sdk/macros/index.mjs
+++ b/util/sdk/macros/index.mjs
@@ -273,7 +273,7 @@ const insertMacros = (fContents = '', macros = {}, module = {}, version = {}) =>
 }
 
 const enumReducer = (acc, val, i, arr) => {
-  const keyName = val.replace(/[\.\-]/g, '_').replace(/\+/g, '_plus').replace(/([a-z])([A-Z0-9])/g, '$1_$2').toUpperCase()
+  const keyName = val.split(':').pop().replace(/[\.\-]/g, '_').replace(/\+/g, '_plus').replace(/([a-z])([A-Z0-9])/g, '$1_$2').toUpperCase()
   acc = acc + `    ${keyName}: '${val}'`
   if (i < arr.length-1) {
     acc = acc.concat(',\n')

--- a/util/shared/javascript.mjs
+++ b/util/shared/javascript.mjs
@@ -17,7 +17,7 @@
  */
 
 const enumReducer = (acc, val, i, arr) => {
-    const keyName = val.replace(/[\.\-]/g, '_').replace(/\+/g, '_plus').replace(/([a-z])([A-Z0-9])/g, '$1_$2').toUpperCase()
+    const keyName = val.split(':').pop().replace(/[\.\-]/g, '_').replace(/\+/g, '_plus').replace(/([a-z])([A-Z0-9])/g, '$1_$2').toUpperCase()
     acc = acc + `    ${keyName}: '${val}'`
     if (i < arr.length-1) {
       acc = acc.concat(',\n')

--- a/util/shared/typescript.mjs
+++ b/util/shared/typescript.mjs
@@ -454,7 +454,7 @@ function getSchemaShape(moduleJson = {}, json = {}, schemas = {}, name = '', opt
   }
 
   const enumReducer = (acc, val, i, arr) => {
-    const keyName = val.replace(/[\.\-]/g, '_').replace(/\+/g, '_plus').replace(/([a-z])([A-Z0-9])/g, '$1_$2').toUpperCase()
+    const keyName = val.split(':').pop().replace(/[\.\-]/g, '_').replace(/\+/g, '_plus').replace(/([a-z])([A-Z0-9])/g, '$1_$2').toUpperCase()
     acc = acc + `    ${keyName} = '${val}'`
     if (i < arr.length-1) {
       acc = acc.concat(',\n')


### PR DESCRIPTION
This change allows for enums to have `:` characters in the values, and still generate language-safe names for each enum.