### PR TITLE
fix: Interfaceless providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^9.0.1",
-    "husky": "^8.0.0",
+    "husky": "^8.0.1",
     "jest": "^27.3.1",
     "semantic-release": "^19.0.5"
   },

--- a/src/js/shared/Events/index.mjs
+++ b/src/js/shared/Events/index.mjs
@@ -229,7 +229,6 @@ export const prioritize = function(...args) {
 }
 
 const unsubscribe = (key) => {
-  console.log(key)
   const [module, event] = key.split('.').slice(0, 2)
   Transport.send(module, 'on' + event[0].toUpperCase() + event.substr(1), { listen: false })
 }

--- a/src/schemas/firebolt-openrpc.json
+++ b/src/schemas/firebolt-openrpc.json
@@ -35,12 +35,22 @@
         "Method": {
             "type": "object",
             "required": [
-                "examples"
+                "examples",
+                "tags"
             ],
             "properties": {
                 "examples": {
                     "type": "array",
                     "minItems": 1
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    },
+                    "contains": {
+                        "$ref": "#/definitions/CapabilitiesTag"
+                    }
                 }
             },
             "allOf": [
@@ -78,8 +88,12 @@
                 },
                 {
                     "if": {
-                        "required": [ "tags"],
+                        "required": [ "tags", "name"],
                         "properties": {
+                            "name": {
+                                "type": "string",
+                                "pattern": "^onRequest"
+                            },
                             "tags": {
                                 "type": "array",
                                 "contains": {
@@ -853,8 +867,28 @@
                         },
                         "x-allow-focus": {
                             "type": "boolean"
+                        },
+                        "x-response-for": {
+                            "type": "string"
+                        },
+                        "x-allow-focus-for": {
+                            "type": "string"
+                        },
+                        "x-error-for": {
+                            "type": "string"
                         }
-                    }
+                    },
+                    "anyOf": [
+                        {
+                            "required": [ "x-uses"]
+                        },
+                        {
+                            "required": [ "x-manages"]
+                        },
+                        {
+                            "required": [ "x-provides"]
+                        }
+                    ]
                 }
             ]
         },

--- a/util/sdk/macros/index.mjs
+++ b/util/sdk/macros/index.mjs
@@ -30,7 +30,7 @@ import predicates from 'crocks/predicates/index.js'
 import isNil from 'crocks/core/isNil.js'
 const { isObject, isArray, propEq, pathSatisfies, propSatisfies } = predicates
 
-import { isExcludedMethod, isRPCOnlyMethod, isProviderMethod, getPayloadFromEvent, providerHasNoParameters, isTemporalSetMethod, hasMethodAttributes, getMethodAttributes, isEventMethodWithContext } from '../../shared/modules.mjs'
+import { isExcludedMethod, isRPCOnlyMethod, isProviderInterfaceMethod, getPayloadFromEvent, providerHasNoParameters, isTemporalSetMethod, hasMethodAttributes, getMethodAttributes, isEventMethodWithContext } from '../../shared/modules.mjs'
 import { getTemplateForMethod } from '../../shared/template.mjs'
 import { getMethodSignatureParams } from '../../shared/javascript.mjs'
 import isEmpty from 'crocks/core/isEmpty.js'
@@ -164,7 +164,7 @@ const providedCapabilitiesOrEmptyArray = compose(
   option([]),
   map(caps => [... new Set(caps)]),
   map(map(m => m.tags.find(t => t['x-provides'])['x-provides'])), // grab the capabilty it provides
-  map(filter(isProviderMethod)),
+  map(filter(isProviderInterfaceMethod)),
   getMethods
 )
 
@@ -180,7 +180,7 @@ const providersOrEmptyArray = compose(
     }
     return e
   })),
-  map(filter(isProviderMethod)),
+  map(filter(isProviderInterfaceMethod)),
   getMethods
 )
 
@@ -469,7 +469,7 @@ function generateMethods(json = {}, templates = {}, onlyEvents = false) {
     option([]),
     map(filter(m => !onlyEvents || isEventMethod(m))),
     map(filter(not(isRPCOnlyMethod))),
-    map(filter(not(isProviderMethod))),
+    map(filter(not(isProviderInterfaceMethod))),
     map(filter(not(isExcludedMethod))),
     getMethods
   )(json)

--- a/util/shared/helpers.mjs
+++ b/util/shared/helpers.mjs
@@ -55,6 +55,7 @@ const clearDirectory = dir => fsRemoveDirectory(dir, {recursive: true})
 const isFile = dir => fsStat(dir).map(statObj => statObj.isFile())
 
 const logSuccess = message => console.log(`\x1b[32m ✓ \x1b[0m\x1b[2m ${message}\x1b[0m`)
+const logInfo = message => console.log(`\x1b[38;5;202m ⓘ \x1b[0m\x1b[2m ${message}\x1b[0m`)
 const logError = message => console.log(`\x1b[31m ✗ \x1b[0m\x1b[2m ${message}\x1b[0m`)
 const logHeader = message => console.log(`\x1b[0m\x1b[7m\x1b[32m${message}\x1b[0m\n`)
 
@@ -277,6 +278,7 @@ export {
   fsWriteFile,
   fsReadFile,
   logSuccess,
+  logInfo,
   logError,
   logHeader,
   getFilename,

--- a/util/shared/typescript.mjs
+++ b/util/shared/typescript.mjs
@@ -20,7 +20,7 @@ import { getPath, getSchema } from './json-schema.mjs'
 import deepmerge from 'deepmerge'
 import { localizeDependencies } from './json-schema.mjs'
 import { getLinkFromRef } from './helpers.mjs'
-import { getMethodsThatProvide, getPayloadFromEvent } from './modules.mjs'
+import {  getProviderInterfaceMethods, getPayloadFromEvent } from './modules.mjs'
 
 const isSynchronous = m => !m.tags ? false : m.tags.map(t => t.name).find(s => s === 'synchronous')
 
@@ -43,6 +43,10 @@ function getProviderName(capability, moduleJson, schemas) {
     return ''
   }
   
+  const prettyName = (moduleJson.info['x-interface-names'] || {})[capability]
+
+  if (prettyName) return prettyName
+
   const capitalize = str => str[0].toUpperCase() + str.substr(1)
   const uglyName = capability.split(":").slice(-2).map(capitalize).reverse().join('') + "Provider"
 
@@ -85,7 +89,7 @@ interface FocusableProviderSession extends ProviderSession {
 
 function getProviderInterface(module, capability, schemas = {}) {
   module = JSON.parse(JSON.stringify(module))
-  const iface = getMethodsThatProvide(capability, module).map(method => localizeDependencies(method, module, schemas, { mergeAllOfs: true }))
+  const iface = getProviderInterfaceMethods(capability, module).map(method => localizeDependencies(method, module, schemas, { mergeAllOfs: true }))
 
   iface.forEach(method => {
     const payload = getPayloadFromEvent(method, module, schemas)

--- a/util/validate/validation/index.mjs
+++ b/util/validate/validation/index.mjs
@@ -40,6 +40,7 @@ const addPrettyPath = (error, json) => {
   })
   error.prettyPath = '/' + path.join('/')
   error.document = root
+  error.node = pointer
   return error
 }
 
@@ -136,6 +137,7 @@ export const displayError = (error) => {
 
   // This is useful for debugging... please leave comment here for quick access :)
   // console.dir(error, {depth: 1000})
+  // console.dir(error.node, {depth: 100})
 
   console.error()
 }


### PR DESCRIPTION
Allows an API to provide a capability with no provider interface, e.g. for push/pull APIs.