### PR TITLE
ci: Release to npm and github on checkin to next

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,28 @@
+name: Check Pull Request
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - 'ready_for_review'
+      - 'opened'
+      - 'reopened'
+      - 'synchronize'
+env:
+  HUSKY: 0
+jobs:
+  release:
+    name: Run npm pack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run validation and tests
+        run: npm pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release to GitHub and NPM
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'next'
 env:
   HUSKY: 0
 jobs:


### PR DESCRIPTION
What was formerly manual is now automated on check-ins to `next` branch.