### PR TITLE
fix(context-params): Register params with correct event name

### DIFF
--- a/src/template/js/methods/event-with-context.js
+++ b/src/template/js/methods/event-with-context.js
@@ -1,1 +1,1 @@
-registerEventContext('${info.title}', '${method.name}', ${method.context.array})
+registerEventContext('${info.title}', '${event.name}', ${method.context.array})


### PR DESCRIPTION
Events with context parameters were not being registered properly due to an `onFoo` vs `foo` mistake in the code.