### PR TITLE
Check template for codeblocks exists or not before trying to generate

### DIFF
--- a/src/macrofier/engine.mjs
+++ b/src/macrofier/engine.mjs
@@ -363,9 +363,22 @@ const makeProviderMethod = x => x.name["onRequest".length].toLowerCase() + x.nam
 //import { default as platform } from '../Platform/defaults'
 const generateAggregateMacros = (openrpc, modules, templates, library) => Object.values(modules)
   .reduce((acc, module) => {
-    acc.exports += insertMacros(getTemplate('/codeblocks/export', templates) + '\n', generateMacros(module, templates))
-    acc.mockImports += insertMacros(getTemplate('/codeblocks/mock-import', templates) + '\n', generateMacros(module, templates))
-    acc.mockObjects += insertMacros(getTemplate('/codeblocks/mock-parameter', templates) + '\n', generateMacros(module, templates))
+
+    let template = getTemplate('/codeblocks/export', templates)
+    if (template) {
+      acc.exports += insertMacros(template + '\n', generateMacros(module, templates))
+    }
+
+    template = getTemplate('/codeblocks/mock-import', templates)
+    if (template) {
+      acc.mockImports += insertMacros(template + '\n', generateMacros(module, templates))
+    }
+
+    template = getTemplate('/codeblocks/mock-parameter', templates)
+    if (template) {
+      acc.mockObjects += insertMacros(template + '\n', generateMacros(module, templates))
+    }
+
     return acc
   }, {
     exports: '',


### PR DESCRIPTION
After adding this check able to reduce 17 minutes  from 25 minutes for Core SDK CPP generations and 2 minute from 3 minutes for Manage SDK CPP code generations