### PR TITLE
Fix: Listeners not honoring multiple failures for subscription

### DIFF
--- a/languages/javascript/src/shared/Events/index.mjs
+++ b/languages/javascript/src/shared/Events/index.mjs
@@ -177,6 +177,9 @@ const doListen = function(module, event, callback, context, once, internal=false
           resolve(listenerId)
         }
         else {
+          // Remove the listerner from Promise list on failure to register
+          const key = module + '.' + event + (hasContext ? `.${contextKey}` : '')
+          delete listeners.external[key][listenerId]
           reject(error)
         }
       })
@@ -184,7 +187,6 @@ const doListen = function(module, event, callback, context, once, internal=false
     else {
       resolve(listenerId)
     }
-
     return p
   }
 }

--- a/languages/javascript/src/shared/Events/index.mjs
+++ b/languages/javascript/src/shared/Events/index.mjs
@@ -177,9 +177,9 @@ const doListen = function(module, event, callback, context, once, internal=false
           resolve(listenerId)
         }
         else {
-          // Remove the listerner from Promise list on failure to register
-          const key = module + '.' + event + (hasContext ? `.${contextKey}` : '')
-          delete listeners.external[key][listenerId]
+          // Remove the listener from external list on failure to subscribe
+          // TODO: Instead of removing, the failed subscription shouldn't be put into the external list
+          listeners.remove(listenerId)
           reject(error)
         }
       })


### PR DESCRIPTION
**Problem:**
> If a call fails when subscribing, the caller will get an error back. 
> However if they call again, then the caller will see success despite the listener never actually getting set.

**Fix:**
> Remove the listener from promise list if failure