### PR TITLE
Fix: Listeners not honoring multiple failures for subscription

### DIFF
--- a/languages/javascript/src/shared/Events/index.mjs
+++ b/languages/javascript/src/shared/Events/index.mjs
@@ -167,22 +167,26 @@ const doListen = function(module, event, callback, context, once, internal=false
       reject = rej
     })
 
-    if (promises.length) {
-      Promise.all(promises).then(responses => {
-        resolve(listenerId)
-      }).catch(error => {
-        // Promise.all rejects if at least one promise rejects... we don't want that behavior here
-        // TODO: Do something better than fail silently
-        if (event === '*') {
-          resolve(listenerId)
-        }
-        else {
-          // Remove the listener from external list on failure to subscribe
-          // TODO: Instead of removing, the failed subscription shouldn't be put into the external list
-          listeners.remove(listenerId)
-          reject(error)
-        }
-      })
+    // Iterate and resolve/reject through the list of promises sequentially
+    const templistenerId = listenerId;
+    if(promises.length) {
+      promises.reduce((prevPromise, currentPromise) => {
+        return prevPromise
+          .then(() => currentPromise)
+          .then(responses => {
+            resolve(templistenerId)
+          })
+          .catch(error => {
+            if (event === '*') {
+              resolve(templistenerId)
+            }
+            else {
+              // Remove the failed listener
+              doClear(templistenerId, event, context)
+              reject(error)
+            }
+          });
+      }, Promise.resolve());
     }
     else {
       resolve(listenerId)


### PR DESCRIPTION
**Problem:**
> If a call fails when subscribing, the caller will get an error back. 
> However if they call again, then the caller will see success despite the listener never actually getting set.

**First attempt:**
> PR #202 - Due to a race condition, the listenerId of a subsequent subscription was dropped.

**Updated fix:**
> Replace promise.all with reduce method to fix race condition and local variable for storing listenerId