### PR TITLE
Feature: connect on demand

### DIFF
--- a/languages/c-structs/templates/sdk/src/Logger/Logger.cpp
+++ b/languages/c-structs/templates/sdk/src/Logger/Logger.cpp
@@ -72,10 +72,11 @@ namespace FireboltSDK {
             const string time = WPEFramework::Core::Time::Now().ToTimeOnly(true);
             const string categoryName =  WPEFramework::Core::EnumerateType<Logger::Category>(category).Data();
             if (categoryName.empty() != true) {
-                sprintf(formattedMsg, "--->\033[1;32m[%s]:[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\n", time.c_str(), categoryName.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
+                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\033[0m\n", time.c_str(), categoryName.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
             } else {
-                sprintf(formattedMsg, "--->\033[1;32m[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\n", time.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
+                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\033[0m\n", time.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
             }
+
             LOG_MESSAGE(formattedMsg);
         }
     }

--- a/languages/c/src/shared/src/Logger/Logger.cpp
+++ b/languages/c/src/shared/src/Logger/Logger.cpp
@@ -74,9 +74,9 @@ namespace FireboltSDK {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
             if (categoryName.empty() != true) {
-                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\n", time.c_str(), categoryName.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
+                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\033[0m\n", time.c_str(), categoryName.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
             } else {
-                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\n", time.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
+                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\033[0m\n", time.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
             }
 #pragma GCC diagnostic pop
             LOG_MESSAGE(formattedMsg);

--- a/languages/cpp/src/shared/src/Accessor/Accessor.h
+++ b/languages/cpp/src/shared/src/Accessor/Accessor.h
@@ -25,6 +25,9 @@
 #include "Event/Event.h"
 #include "Logger/Logger.h"
 
+#include <condition_variable>
+#include <mutex>
+
 namespace FireboltSDK {
     class Accessor {
     private:
@@ -107,7 +110,8 @@ namespace FireboltSDK {
 
         Firebolt::Error Connect(const Transport<WPEFramework::Core::JSON::IElement>::Listener& listener)
         {
-            Firebolt::Error status = CreateTransport(_config.WsUrl.Value().c_str(), listener, _config.WaitTime.Value());
+            RegisterConnectionChangeListener(listener);
+            Firebolt::Error status = CreateTransport(_config.WsUrl.Value().c_str(), _config.WaitTime.Value());
             if (status == Firebolt::Error::None) {
                 Async::Instance().Configure(_transport);
                 status = CreateEventHandler();
@@ -115,8 +119,21 @@ namespace FireboltSDK {
             return status;
         }
 
+        void RegisterConnectionChangeListener(const Transport<WPEFramework::Core::JSON::IElement>::Listener& listener)
+        {
+            _connectionChangeListener = listener;
+        }
+
+        void UnregisterConnnectionChangeListener()
+        {
+            _connectionChangeListener = nullptr;
+        }
+
         Firebolt::Error Disconnect()
         {
+            if (_transport == nullptr) {
+                return Firebolt::Error::None;
+            }
             Firebolt::Error status = Firebolt::Error::None;
             status = DestroyTransport();
             if (status == Firebolt::Error::None) {
@@ -126,19 +143,49 @@ namespace FireboltSDK {
             return status;
         }
 
+        bool IsConnected() const
+        {
+            return _connected;
+        }
+
         Event& GetEventManager();
         Transport<WPEFramework::Core::JSON::IElement>* GetTransport();
 
     private:
         Firebolt::Error CreateEventHandler();
         Firebolt::Error DestroyEventHandler();
-        Firebolt::Error CreateTransport(const string& url, const Transport<WPEFramework::Core::JSON::IElement>::Listener& listener, const uint32_t waitTime);
+        Firebolt::Error CreateTransport(const string& url, const uint32_t waitTime);
         Firebolt::Error DestroyTransport();
+
+        void ConnectionChanged(const bool connected, const Firebolt::Error error);
 
     private:
         WPEFramework::Core::ProxyType<WorkerPoolImplementation> _workerPool;
         Transport<WPEFramework::Core::JSON::IElement>* _transport;
         static Accessor* _singleton;
         Config _config;
+        struct {
+            std::mutex m;
+            std::condition_variable cv;
+            bool ready = false;
+            void reset() {
+                std::lock_guard lk(m);
+                ready = false;
+            }
+            bool wait_for(unsigned duration_ms) {
+                std::unique_lock lk(m);
+                bool ret = cv.wait_for(lk, std::chrono::milliseconds(duration_ms), [&]{ return ready; });
+                lk.unlock();
+                return ret;
+            }
+            void signal() {
+                std::lock_guard lk(m);
+                ready = true;
+                cv.notify_one();
+            }
+        } _connectionChangeSync; // Synchronize a thread that is waiting for a connection if that one that is notified about connection changes
+
+        bool _connected = false;
+        Transport<WPEFramework::Core::JSON::IElement>::Listener _connectionChangeListener = nullptr;
     };
 }

--- a/languages/cpp/src/shared/src/Logger/Logger.cpp
+++ b/languages/cpp/src/shared/src/Logger/Logger.cpp
@@ -76,9 +76,9 @@ namespace FireboltSDK {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
             if (categoryName.empty() != true) {
-                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\n", time.c_str(), categoryName.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
+                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\033[0m\n", time.c_str(), categoryName.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
             } else {
-                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\n", time.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
+                snprintf(formattedMsg, sizeof(formattedMsg), "--->\033[1;32m[%s]:[%s][%s:%d](%s)<PID:%d><TID:%ld> : %s\033[0m\n", time.c_str(), module.c_str(), WPEFramework::Core::File::FileName(file).c_str(), line, function.c_str(), TRACE_PROCESS_ID, TRACE_THREAD_ID, msg);
             }
 #pragma GCC diagnostic pop
             LOG_MESSAGE(formattedMsg);

--- a/languages/cpp/templates/sdk/include/firebolt.h
+++ b/languages/cpp/templates/sdk/include/firebolt.h
@@ -89,6 +89,29 @@ struct IFireboltAccessor {
     virtual Firebolt::Error Connect ( OnConnectionChanged listener ) = 0;
 
     /**
+     * @brief Register a callback for any changes in the connection to the endpoint. Only a single callback is supported.
+     *
+     * @param listener Connection status listener
+     *
+     * @return None
+     */
+    virtual void RegisterConnectionChangeListener ( OnConnectionChanged listener ) = 0;
+
+    /**
+     * @brief Unregister previously registered callback.
+     *
+     * @return None
+     */
+    virtual void UnregisterConnnectionChangeListener ( ) = 0;
+
+    /**
+     * @brief Returs whether there is a connection to the endpoint
+     *
+     * @return bool
+     */
+    virtual bool IsConnected ( ) const = 0;
+
+    /**
      * @brief Disconnects from the Websocket endpoint.
      * 
      * @return Firebolt::Error

--- a/languages/cpp/templates/sdk/scripts/build.sh
+++ b/languages/cpp/templates/sdk/scripts/build.sh
@@ -37,9 +37,9 @@ then
 fi
 
 rm -rf ${SdkPath}/build/src/libFireboltSDK.so
-cmake -B${SdkPath}/build -S${SdkPath} -DSYSROOT_PATH=${SysrootPath} -DENABLE_TESTS=${EnableTest} -DHIDE_NON_EXTERNAL_SYMBOLS=OFF -DFIREBOLT_ENABLE_STATIC_LIB=${EnableStaticLib}
-cmake --build ${SdkPath}/build
+cmake -B${SdkPath}/build -S${SdkPath} -DSYSROOT_PATH=${SysrootPath} -DENABLE_TESTS=${EnableTest} -DHIDE_NON_EXTERNAL_SYMBOLS=OFF -DFIREBOLT_ENABLE_STATIC_LIB=${EnableStaticLib} || exit 1
+cmake --build ${SdkPath}/build || exit 1
 if [ -f "${SdkPath}/build/src/libFireboltSDK.so" ];
 then
-    cmake --install ${SdkPath}/build --prefix ${SdkPath}/build/Firebolt/usr
+    cmake --install ${SdkPath}/build --prefix ${SdkPath}/build/Firebolt/usr || exit 1
 fi

--- a/languages/cpp/templates/sdk/src/firebolt.cpp
+++ b/languages/cpp/templates/sdk/src/firebolt.cpp
@@ -89,6 +89,21 @@ namespace Firebolt {
             return _accessor->Connect(listener);
         }
 
+        void RegisterConnectionChangeListener( OnConnectionChanged listener ) override
+        {
+            return _accessor->RegisterConnectionChangeListener(listener);
+        }
+
+        void UnregisterConnnectionChangeListener() override
+        {
+            _accessor->UnregisterConnnectionChangeListener();
+        }
+
+        bool IsConnected() const override
+        {
+            return _accessor->IsConnected();
+        }
+
         Firebolt::Error Disconnect() override
         {
             return _accessor->Disconnect();

--- a/languages/cpp/templates/sdk/src/firebolt.cpp
+++ b/languages/cpp/templates/sdk/src/firebolt.cpp
@@ -51,9 +51,11 @@ namespace Firebolt {
 
         static FireboltAccessorImpl& Instance()
         {
-            static FireboltAccessorImpl* instance = new FireboltAccessorImpl();
-            ASSERT(instance != nullptr);
-            return *instance;
+            if (_singleton == nullptr) {
+                _singleton = new FireboltAccessorImpl();
+                ASSERT(_singleton != nullptr);
+            }
+            return *_singleton;
         }
 
         static void Dispose()
@@ -67,6 +69,7 @@ namespace Firebolt {
             ASSERT(_singleton != nullptr);
             if (_singleton != nullptr) {
                 delete _singleton;
+                singleton = nullptr;
             }
         }
 


### PR DESCRIPTION
Removes the need for the application to connect to the endpoint before using Firebolt, in other words, Firebolt will connect when necessary, on the first request. Also, if a disconnection occurs, Firebolt will try to reconnect when needed.

If the application stops using `Firebolt::IFireboltAccessor::Instance().Connect()`, it is not be notified about connection changes because connection change listener is provided in `Connect()`. To avoid that and allows the application to be notified and check status of connection, the following methods have been introduced:
- `RegisterConnectionChangeListener()` & `UnregisterConnectionChangeListener()`
- `IsConnected()`

Other fixes:
* If build step fails, build script exits with an error
* Log traces stop coloring on EOL
* `Firebolt::IFireboltAccessor::Instance()`: the instance in kept in a single variable: `_singleton`, additional one `instance` has been removed