### PR TITLE
fix: UB when reinterpret cast on an object with multiple inheritance

### DIFF
--- a/languages/cpp/templates/codeblocks/module-init.cpp
+++ b/languages/cpp/templates/codeblocks/module-init.cpp
@@ -1,13 +1,13 @@
 ${if.modules}        ${info.Title}::I${info.Title}& ${info.Title}Interface() const override
         {
             auto module = _moduleMap.find("${info.Title}");
-            ${info.Title}::I${info.Title}* ${info.title.lowercase} = nullptr;
+            ${info.Title}::${info.Title}Impl* ${info.title.lowercase} = nullptr;
 
             if (module != _moduleMap.end()) {
-                ${info.title.lowercase} = reinterpret_cast<${info.Title}::I${info.Title}*>(module->second);
+                ${info.title.lowercase} = dynamic_cast<${info.Title}::${info.Title}Impl*>(module->second);
             } else {
-                ${info.title.lowercase} = reinterpret_cast<${info.Title}::I${info.Title}*>(new ${info.Title}::${info.Title}Impl());
-                _moduleMap.emplace("${info.Title}", reinterpret_cast<IModule*>(${info.title.lowercase}));
+                ${info.title.lowercase} = new ${info.Title}::${info.Title}Impl();
+                _moduleMap.emplace("${info.Title}", ${info.title.lowercase});
             }
             return *${info.title.lowercase};
         }


### PR DESCRIPTION
Fixed undefined behaviour caused by using reinterpret cast on an object with multiple inheritance