### PR TITLE
build: Update setup-node in github action

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           repo-token: ${{ secrets.SEMANTIC_RELEASE_BOT_PAT }}
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Set explicit npm dist-tag default


### PR DESCRIPTION
setup-node@v2 used outdated version of actions/cache

---
In firebold-apis github actions started to fail with the following error:
```
  Run actions/setup-node@v2
  Attempt to resolve LTS alias from manifest...
  Found in cache @ /opt/hostedtoolcache/node/22.15.0/x64
  /opt/hostedtoolcache/node/22.15.0/x64/bin/npm config get cache
  /home/runner/.npm
  Error: Cache service responded with 422
```