### PR TITLE
fix: Omit private methods from doc ToC

### DIFF
--- a/languages/markdown/templates/sections/private-events.md
+++ b/languages/markdown/templates/sections/private-events.md
@@ -1,6 +1,3 @@
 ## Private Events
-<details id="private-events-details">
-  <summary>View</summary>
 
-  ${event.list}
-</details>
+${event.list}

--- a/languages/markdown/templates/sections/private-methods.md
+++ b/languages/markdown/templates/sections/private-methods.md
@@ -1,6 +1,3 @@
 ## Private Methods
-<details id="private-methods-details">
-  <summary>View</summary>
 
-  ${method.list}
-</details>
+${method.list}

--- a/src/macrofier/engine.mjs
+++ b/src/macrofier/engine.mjs
@@ -732,20 +732,20 @@ function insertTableofContents(content) {
   let toc = ''
   const count = {}
   const slugger = title => title.toLowerCase().replace(/ /g, '-').replace(/-+/g, '-').replace(/[^a-zA-Z-]/g, '')
-  let collapsedContentLevel = null
+  let inPrivateSection = false
 
   content.split('\n').filter(line => line.match(/^\#/)).map(line => {
     const match = line.match(/^(\#+) (.*)/)
-    if (match) {
+
+    if (!match) { return }
+
+    // level 2 == section title (Usage, Overview, Methods, etc)
+    // level 3 == method/event names; we'll only list public methods/events in the ToC
+    // level 4 == examples; we'll ignore these in the ToC
       const level = match[1].length
-      if (level > 1 && level < 4) {
-        if (collapsedContentLevel === level) {
-          // we are back to the level we started the collapsed content, end the collapse
-          toc += ' ' + '  '.repeat(collapsedContentLevel) + '</details>\n'
-          collapsedContentLevel = null
-        }
         const title = match[2]
         const slug = slugger(title)
+
         if (count.hasOwnProperty(slug)) {
           count[slug] += 1
         }
@@ -753,15 +753,21 @@ function insertTableofContents(content) {
           count[slug] = 0
         }
         const link = '#' + slug + (count[slug] ? `-${count[slug]}` : '')
-        toc += ' ' + '  '.repeat(level - 1) + `- [${title}](${link})`
-        if (title === 'Private Methods' || title === 'Private Events') {
-          let anchor = title === 'Private Methods' ? 'private-methods-details' : 'private-events-details'
-          toc += '<details ontoggle="document.getElementById(\'' + anchor + '\').open=this.open"><summary>Show</summary>\n'
-          collapsedContentLevel = level
-        } else {
-          toc += '\n'
-        }
+
+    if (level == 2 || level == 3) {
+      if (inPrivateSection) {
+        // we're currently in a private section and don't want to output private methods/events in ToC
+        if (level == 3) { return }
+
+        // we've dropped out of a private section, output methods as normal
+        inPrivateSection = false
       }
+
+        if (title === 'Private Methods' || title === 'Private Events') {
+        inPrivateSection = true
+      }
+
+      toc += '  '.repeat(level - 2) + `- [${title}](${link})\n`
     }
   }).join('\n')
 


### PR DESCRIPTION
The documentation portal has an issue where HTML tags are being escaped/not properly handled by Jekyll.  I don't think this is an issue with Jekyll, but rather in how we're mixing markdown with HTML in a non-standard way (this wasn't tested against the Comcast doc portal yet).

This mainly affects the private methods/events, which were intended to be "hidden" behind a dropdown in the Table of Contents.e.g.:

<img width="814" height="896" alt="Screenshot 2025-09-11 at 12 02 28 PM" src="https://github.com/user-attachments/assets/a5c44221-f9ad-4afa-85ea-8c7440359d0a" />

This changes updates the logic to remove the hidden methods/broken HTML, and instead replace it with a link to the private methods/events section.

<img width="835" height="834" alt="Screenshot 2025-09-11 at 12 02 43 PM" src="https://github.com/user-attachments/assets/22a6d706-18d7-485d-97e1-edceec1c6959" />
